### PR TITLE
fix: correct 'ETH' typo in user texts

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -51,7 +51,7 @@ export default function AboutSection() {
         transition={{ duration: 0.5, delay: 0.3 }}
         viewport={{ once: true }}
       >
-        Currently focused on Ethereum and testnets. Multi-chain and Beth transactions coming soon.
+        Currently focused on Ethereum and testnets. Multi-chain and ETH transactions coming soon.
       </motion.p>
     </section>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -23,7 +23,7 @@ export default function Hero() {
           No clutter. No noise. Just a clean, secure way to connect to crypto — built for real people in a real world.
         </p>
         <p className="text-gray-500 text-sm">
-          Currently focused on Ethereum and testnets. Multi-chain and Beth transactions coming soon.
+          Currently focused on Ethereum and testnets. Multi-chain and ETH transactions coming soon.
         </p>
 
         <div className="flex flex-col sm:flex-row gap-4 items-center sm:items-stretch justify-center">

--- a/src/components/RoadmapTimeline.tsx
+++ b/src/components/RoadmapTimeline.tsx
@@ -9,8 +9,8 @@ const roadmap = [
     date: 'May 2025',
   },
   {
-    title: 'Token sending (Beth)',
-    description: 'Ability to send ETH (Beth) directly from the dashboard.',
+    title: 'Token sending (ETH)',
+    description: 'Ability to send ETH (ETH) directly from the dashboard.',
     date: 'Coming Soon',
   },
   {


### PR DESCRIPTION
## Summary
- update hero, about section, and roadmap text to say **ETH** instead of **Beth**

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed42e0a08322b20a4e98c0ca0eac