### PR TITLE
Fix create profile upsert field

### DIFF
--- a/src/components/CreateProfileForm.tsx
+++ b/src/components/CreateProfileForm.tsx
@@ -42,8 +42,8 @@ export default function CreateProfileForm({ address }: { address: string }) {
     // Si no existe, lo creamos
     const { error: insertError } = await supabase
       .from('profiles')
-      .upsert(
-        { wallet_address: address, name, email },
+        .upsert(
+          { wallet_address: address, username, email },
         { onConflict: 'wallet_address' }
       );
 


### PR DESCRIPTION
## Summary
- fix property name in `CreateProfileForm` when calling supabase `upsert`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file)*
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed8e6fa08322bb6e1b328495bd94