### PR TITLE
fix: use username field when creating profile

### DIFF
--- a/src/components/CreateProfileForm.tsx
+++ b/src/components/CreateProfileForm.tsx
@@ -43,7 +43,7 @@ export default function CreateProfileForm({ address }: { address: string }) {
     const { error: insertError } = await supabase
       .from('profiles')
       .upsert(
-        { wallet_address: address, name, email },
+        { wallet_address: address, username, email },
         { onConflict: 'wallet_address' }
       );
 


### PR DESCRIPTION
## Summary
- ensure profile creation uses the `username` field

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed1efb248322b40512b9c8798d3b