### PR TITLE
Add env parsing and replace process.env usages

### DIFF
--- a/src/app/api/etherscan/route.ts
+++ b/src/app/api/etherscan/route.ts
@@ -1,7 +1,8 @@
 // src/api/etherscan/route.ts
-import { NextResponse } from 'next/server';
+import { NextResponse } from 'next/server'
+import { env } from '@/lib/env'
 
-const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;
+const ETHERSCAN_API_KEY = env.ETHERSCAN_API_KEY
 const ETHERSCAN_BASE_URL = 'https://api.etherscan.io/api';
 
 export async function GET(request: Request) {

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -8,16 +8,17 @@ import { parseEther } from 'viem';
 import { useAccount, useSendTransaction } from 'wagmi';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import QRCode from 'react-qr-code';
-import PageLayout from '@/components/PageLayout';
-import { CryptoLogos } from '../wallet/components/CryptoLogos';
+import PageLayout from '@/components/PageLayout'
+import { CryptoLogos } from '../wallet/components/CryptoLogos'
+import { env } from '@/lib/env'
 
 const WALLETS: Record<string, string> = {
-  ETH: process.env.NEXT_PUBLIC_ETH_WALLET!,
-  BTC: process.env.NEXT_PUBLIC_BITCOIN_WALLET!,
-  SOL: process.env.NEXT_PUBLIC_SOLANA_WALLET!,
-  LTC: process.env.NEXT_PUBLIC_LITECOIN_WALLET!,
-  DOGE: process.env.NEXT_PUBLIC_DOGECOIN_WALLET!,
-};
+  ETH: env.NEXT_PUBLIC_ETH_WALLET,
+  BTC: env.NEXT_PUBLIC_BITCOIN_WALLET,
+  SOL: env.NEXT_PUBLIC_SOLANA_WALLET,
+  LTC: env.NEXT_PUBLIC_LITECOIN_WALLET,
+  DOGE: env.NEXT_PUBLIC_DOGECOIN_WALLET,
+}
 
 const explorers: Record<string, string> = {
   ETH: 'https://etherscan.io/tx/',

--- a/src/app/wallet/components/DonateWidget.tsx
+++ b/src/app/wallet/components/DonateWidget.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import { useState } from 'react';
-import { FaCheck, FaRegCopy, FaSpinner } from 'react-icons/fa';
-import { motion, AnimatePresence } from 'framer-motion';
-import { parseEther } from 'viem';
-import { useAccount, useSendTransaction } from 'wagmi';
-import { ConnectButton } from '@rainbow-me/rainbowkit';
-import QRCode from 'react-qr-code';
+import { useState } from 'react'
+import { FaCheck, FaRegCopy, FaSpinner } from 'react-icons/fa'
+import { motion, AnimatePresence } from 'framer-motion'
+import { parseEther } from 'viem'
+import { useAccount, useSendTransaction } from 'wagmi'
+import { ConnectButton } from '@rainbow-me/rainbowkit'
+import QRCode from 'react-qr-code'
+import { env } from '@/lib/env'
 
 const WALLETS: Record<string, string> = {
-  ETH: process.env.NEXT_PUBLIC_ETH_WALLET!,
-  BTC: process.env.NEXT_PUBLIC_BITCOIN_WALLET!,
-  SOL: process.env.NEXT_PUBLIC_SOLANA_WALLET!,
-  LTC: process.env.NEXT_PUBLIC_LITECOIN_WALLET!,
-  DOGE: process.env.NEXT_PUBLIC_DOGECOIN_WALLET!,
-};
+  ETH: env.NEXT_PUBLIC_ETH_WALLET,
+  BTC: env.NEXT_PUBLIC_BITCOIN_WALLET,
+  SOL: env.NEXT_PUBLIC_SOLANA_WALLET,
+  LTC: env.NEXT_PUBLIC_LITECOIN_WALLET,
+  DOGE: env.NEXT_PUBLIC_DOGECOIN_WALLET,
+}
 
 const explorers: Record<string, string> = {
   ETH: 'https://etherscan.io/tx/',

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,6 +1,7 @@
+import { env } from './env'
+
 export async function subscribeToBrevo(email: string) {
-  const apiKey = process.env.BREVO_API_KEY;
-  if (!apiKey) throw new Error('Brevo API key not set in environment variables');
+  const apiKey = env.BREVO_API_KEY
 
   const res = await fetch('https://api.brevo.com/v3/contacts', {
     method: 'POST',

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+  NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID: z.string(),
+  NEXT_PUBLIC_ETHERSCAN_API_KEY: z.string(),
+  ETHERSCAN_API_KEY: z.string(),
+  BREVO_API_KEY: z.string(),
+  NEXT_PUBLIC_ETH_WALLET: z.string(),
+  NEXT_PUBLIC_BITCOIN_WALLET: z.string(),
+  NEXT_PUBLIC_SOLANA_WALLET: z.string(),
+  NEXT_PUBLIC_LITECOIN_WALLET: z.string(),
+  NEXT_PUBLIC_DOGECOIN_WALLET: z.string(),
+})
+
+export const env = envSchema.parse(process.env)

--- a/src/lib/fetchTransactions.ts
+++ b/src/lib/fetchTransactions.ts
@@ -1,4 +1,6 @@
-const ETHERSCAN_API_KEY = process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY;
+import { env } from './env'
+
+const ETHERSCAN_API_KEY = env.NEXT_PUBLIC_ETHERSCAN_API_KEY
 const ETHERSCAN_API_URL = 'https://api.etherscan.io/api';
 
 export interface EtherscanTransaction {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,7 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js'
+import { env } from './env'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,11 +1,12 @@
 // src/lib/wallet.ts
-import { getDefaultConfig } from '@rainbow-me/rainbowkit';
-import { mainnet, polygon, optimism, arbitrum } from 'wagmi/chains';
-import { http } from 'wagmi';
+import { getDefaultConfig } from '@rainbow-me/rainbowkit'
+import { mainnet, polygon, optimism, arbitrum } from 'wagmi/chains'
+import { http } from 'wagmi'
+import { env } from './env'
 
 export const config = getDefaultConfig({
   appName: 'Dripnex',
-  projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID!,
+  projectId: env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
   chains: [mainnet, polygon, optimism, arbitrum],
   transports: {
     [mainnet.id]: http(),

--- a/src/services/etherscan.ts
+++ b/src/services/etherscan.ts
@@ -1,11 +1,13 @@
 // src/services/etherscan.ts
 
-const ETHERSCAN_BASE_URL = 'https://api.etherscan.io/api';
+import { env } from '@/lib/env'
+
+const ETHERSCAN_BASE_URL = 'https://api.etherscan.io/api'
 
 export async function getTransactions(address: string) {
   const res = await fetch(
-    `${ETHERSCAN_BASE_URL}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&sort=desc&apikey=${process.env.ETHERSCAN_API_KEY}`
-  );
+    `${ETHERSCAN_BASE_URL}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&sort=desc&apikey=${env.ETHERSCAN_API_KEY}`
+  )
 
   const data = await res.json();
 


### PR DESCRIPTION
## Summary
- centralize runtime configuration under `src/lib/env.ts`
- consume parsed env vars across the app

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d6dedb4883228694f8b889400f2a