### PR TITLE
Refactor transaction fetch flow

### DIFF
--- a/src/app/api/etherscan/route.ts
+++ b/src/app/api/etherscan/route.ts
@@ -18,10 +18,21 @@ export async function GET(request: Request) {
     const data = await res.json();
 
     if (data.status !== '1') {
-      return NextResponse.json({ error: data.message || 'Failed to fetch transactions' }, { status: 500 });
+      return NextResponse.json(
+        { error: data.message || 'Failed to fetch transactions' },
+        { status: 500 }
+      );
     }
 
-    return NextResponse.json({ transactions: data.result });
+    const transactions = (data.result || []).map((tx: any) => ({
+      hash: tx.hash,
+      from: tx.from,
+      to: tx.to,
+      value: (parseFloat(tx.value) / 1e18).toFixed(4),
+      timeStamp: tx.timeStamp,
+    }));
+
+    return NextResponse.json({ transactions });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/wallet/WalletDashboard.tsx
+++ b/src/app/wallet/WalletDashboard.tsx
@@ -26,7 +26,15 @@ export default function WalletDashboard() {
 
   useEffect(() => {
     if (!address || !isConnected) return;
-    fetchTransactions(address).then(setTransactions).catch(console.error);
+    fetchTransactions(address)
+      .then((data) => {
+        if (!data.error) {
+          setTransactions(data.transactions);
+        } else {
+          console.error(data.error);
+        }
+      })
+      .catch(console.error);
   }, [address, isConnected]);
 
   if (!isConnected || !address) return null;

--- a/src/lib/fetchTransactions.ts
+++ b/src/lib/fetchTransactions.ts
@@ -1,20 +1,3 @@
-const ETHERSCAN_API_KEY = process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY;
-const ETHERSCAN_API_URL = 'https://api.etherscan.io/api';
-
-export interface EtherscanTransaction {
-  hash: string;
-  from: string;
-  to: string;
-  value: string;
-  timeStamp: string;
-}
-
-interface EtherscanResponse {
-  status: string;
-  message: string;
-  result: EtherscanTransaction[];
-}
-
 export interface ParsedTransaction {
   hash: string;
   from: string;
@@ -22,26 +5,16 @@ export interface ParsedTransaction {
   value: string; // ya convertido a ETH con toFixed
   timeStamp: string;
   token?: string; // ✅ opcional, si no siempre está presente
-
+}
+interface ApiResponse {
+  transactions: ParsedTransaction[];
+  error?: string;
 }
 
-export async function fetchTransactions(address: string): Promise<ParsedTransaction[]> {
-  if (!ETHERSCAN_API_KEY) throw new Error('Falta la API Key de Etherscan');
+export async function fetchTransactions(address: string): Promise<ApiResponse> {
+  const res = await fetch(`/api/etherscan?address=${address}`);
+  const data = await res.json();
 
-  const url = `${ETHERSCAN_API_URL}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&sort=desc&apikey=${ETHERSCAN_API_KEY}`;
-
-  const res = await fetch(url);
-  const data: EtherscanResponse = await res.json();
-
-  if (!data.result || data.result.length === 0) {
-    return [];
-  }
-
-  return data.result.map((tx) => ({
-    hash: tx.hash,
-    from: tx.from,
-    to: tx.to,
-    value: (parseFloat(tx.value) / 1e18).toFixed(4),
-    timeStamp: tx.timeStamp,
-  }));
+  return data;
 }
+


### PR DESCRIPTION
## Summary
- remove direct etherscan call from `fetchTransactions`
- fetch transactions via `/api/etherscan`
- parse transactions in the API route
- adapt `WalletDashboard` to new API response

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d6db7f8483229768299354a4ea5d