### PR TITLE
Use redis-backed rate limiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-icons": "^5.5.0",
     "react-qr-code": "^2.0.15",
     "sib-api-v3-sdk": "^8.5.0",
+    "@upstash/redis": "^1.34.3",
     "viem": "^2.30.5",
     "wagmi": "^2.15.4",
     "zod": "^3.25.42",

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
       req.headers.get('x-real-ip') ||
       'unknown';
 
-    if (isRateLimited(ip)) {
+    if (await isRateLimited(ip)) {
       return NextResponse.json(
         { message: 'Too many requests' },
         { status: 429 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -12,6 +12,8 @@ const envSchema = z.object({
   NEXT_PUBLIC_SOLANA_WALLET: z.string(),
   NEXT_PUBLIC_LITECOIN_WALLET: z.string(),
   NEXT_PUBLIC_DOGECOIN_WALLET: z.string(),
+  UPSTASH_REDIS_REST_URL: z.string().url(),
+  UPSTASH_REDIS_REST_TOKEN: z.string(),
 })
 
 export const env = envSchema.parse(process.env)


### PR DESCRIPTION
## Summary
- depend on `@upstash/redis`
- wire redis config via `env`
- implement redis-based `rateLimiter`
- call updated async limiter in the subscribe API

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dd6cba6c8322958836996fe2035a