### PR TITLE
Add vitest setup and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     "postcss": "^8.5.4",
     "tailwindcss": "3.4",
     "typescript": "^5",
-    "vitest": "^1.4.0"
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^22.1.0"
   }
 }

--- a/src/app/api/etherscan/route.test.ts
+++ b/src/app/api/etherscan/route.test.ts
@@ -1,0 +1,11 @@
+import { GET } from './route';
+import { describe, it, expect } from 'vitest';
+
+describe('GET /api/etherscan', () => {
+  it('returns 400 when address is missing', async () => {
+    const res = await GET(new Request('http://test.com/api/etherscan'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Missing wallet address' });
+  });
+});

--- a/src/app/api/subscribe/route.test.ts
+++ b/src/app/api/subscribe/route.test.ts
@@ -1,0 +1,16 @@
+import { POST } from './route';
+import { describe, it, expect } from 'vitest';
+
+describe('POST /api/subscribe', () => {
+  it('returns 400 for invalid email', async () => {
+    const req = new Request('http://test.com/api/subscribe', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'invalid' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ message: 'Invalid email' });
+  });
+});

--- a/src/app/hooks/useSendETH.test.ts
+++ b/src/app/hooks/useSendETH.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useSendEth } from './useSendETH';
+
+const mockSendTransaction = vi.fn((_, { onSuccess }) => {
+  onSuccess('0xtest');
+});
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: '0x123' }),
+  useSendTransaction: () => ({
+    sendTransaction: mockSendTransaction,
+    isPending: false,
+    data: undefined,
+    error: undefined,
+    isError: false,
+  }),
+  useWaitForTransactionReceipt: () => ({
+    isSuccess: true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('viem', () => ({
+  parseEther: (v: string) => v,
+}));
+
+test('send calls wagmi and updates txHash', () => {
+  const { result } = renderHook(() => useSendEth());
+  act(() => {
+    result.current.send('0xabc', '1');
+  });
+  expect(mockSendTransaction).toHaveBeenCalledWith(
+    { to: '0xabc', value: '1' },
+    expect.objectContaining({ onSuccess: expect.any(Function) })
+  );
+  expect(result.current.txHash).toBe('0xtest');
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- add vitest config with jsdom
- include React testing libs and jsdom as dev dependencies
- add CI workflow to run vitest
- test `useSendEth` hook
- test API route validation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dd70beb88322b0bc32160ef22e4f