### PR TITLE
Add etherscan address validation

### DIFF
--- a/src/app/api/etherscan/route.test.ts
+++ b/src/app/api/etherscan/route.test.ts
@@ -8,4 +8,11 @@ describe('GET /api/etherscan', () => {
     const body = await res.json();
     expect(body).toEqual({ error: 'Missing wallet address' });
   });
+
+  it('returns 400 for invalid address', async () => {
+    const res = await GET(new Request('http://test.com/api/etherscan?address=bad'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Invalid address' });
+  });
 });

--- a/src/app/api/etherscan/route.ts
+++ b/src/app/api/etherscan/route.ts
@@ -13,6 +13,10 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Missing wallet address' }, { status: 400 });
   }
 
+  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    return NextResponse.json({ error: 'Invalid address' }, { status: 400 });
+  }
+
   try {
     const url = `${ETHERSCAN_BASE_URL}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&sort=desc&apikey=${ETHERSCAN_API_KEY}`;
     const res = await fetch(url);


### PR DESCRIPTION
## Summary
- validate wallet address format before hitting Etherscan API
- return a 400 response when the address is invalid
- test invalid address handling in Etherscan route

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ee24a1108322ad4853211492c6e3