### PR TITLE
Centralize donation constants

### DIFF
--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -10,23 +10,7 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 import QRCode from 'react-qr-code';
 import PageLayout from '@/components/PageLayout'
 import { CryptoLogos } from '../wallet/components/CryptoLogos'
-import { env } from '@/lib/env'
-
-const WALLETS: Record<string, string> = {
-  ETH: env.NEXT_PUBLIC_ETH_WALLET,
-  BTC: env.NEXT_PUBLIC_BITCOIN_WALLET,
-  SOL: env.NEXT_PUBLIC_SOLANA_WALLET,
-  LTC: env.NEXT_PUBLIC_LITECOIN_WALLET,
-  DOGE: env.NEXT_PUBLIC_DOGECOIN_WALLET,
-}
-
-const explorers: Record<string, string> = {
-  ETH: 'https://etherscan.io/tx/',
-  BTC: 'https://www.blockchain.com/btc/tx/',
-  SOL: 'https://solscan.io/tx/',
-  LTC: 'https://blockchair.com/litecoin/transaction/',
-  DOGE: 'https://blockchair.com/dogecoin/transaction/',
-};
+import { WALLETS, EXPLORERS } from '@/lib/donation'
 
 const suggestedAmounts = ['0.01', '0.05', '0.1', '0.5', '1'];
 const cryptoOptions = ['ETH', 'BTC', 'SOL', 'LTC', 'DOGE'] as const;
@@ -48,7 +32,7 @@ export default function DonatePage() {
   } = useSendTransaction();
 
   const address = WALLETS[selectedCrypto];
-  const explorerBase = explorers[selectedCrypto];
+  const explorerBase = EXPLORERS[selectedCrypto];
 
   const handleCopyAddress = () => {
     navigator.clipboard.writeText(address);

--- a/src/app/wallet/components/DonateWidget.tsx
+++ b/src/app/wallet/components/DonateWidget.tsx
@@ -6,23 +6,7 @@ import { CryptoType } from './cryptoTypes'
 import CryptoSelector from './CryptoSelector'
 import AmountInput from './AmountInput'
 import SendDonation from './SendDonation'
-import { env } from '@/lib/env'
-
-const WALLETS: Record<string, string> = {
-  ETH: env.NEXT_PUBLIC_ETH_WALLET,
-  BTC: env.NEXT_PUBLIC_BITCOIN_WALLET,
-  SOL: env.NEXT_PUBLIC_SOLANA_WALLET,
-  LTC: env.NEXT_PUBLIC_LITECOIN_WALLET,
-  DOGE: env.NEXT_PUBLIC_DOGECOIN_WALLET,
-}
-
-const explorers: Record<string, string> = {
-  ETH: 'https://etherscan.io/tx/',
-  BTC: 'https://www.blockchain.com/btc/tx/',
-  SOL: 'https://solscan.io/tx/',
-  LTC: 'https://blockchair.com/litecoin/transaction/',
-  DOGE: 'https://blockchair.com/dogecoin/transaction/',
-};
+import { WALLETS, EXPLORERS } from '@/lib/donation'
 
 
 interface DonateWidgetProps {
@@ -42,7 +26,7 @@ export default function DonateWidget({
   const [amount, setAmount] = useState('0.01');
 
   const address = WALLETS[selectedCrypto];
-  const explorerBase = explorers[selectedCrypto];
+  const explorerBase = EXPLORERS[selectedCrypto];
 
   return (
     <section className="w-full max-w-full rounded-2xl shadow-2xl p-8 border border-white/10 backdrop-blur bg-black/30 space-y-8 text-white">

--- a/src/lib/donation.ts
+++ b/src/lib/donation.ts
@@ -1,0 +1,17 @@
+import { env } from './env'
+
+export const WALLETS: Record<string, string> = {
+  ETH: env.NEXT_PUBLIC_ETH_WALLET,
+  BTC: env.NEXT_PUBLIC_BITCOIN_WALLET,
+  SOL: env.NEXT_PUBLIC_SOLANA_WALLET,
+  LTC: env.NEXT_PUBLIC_LITECOIN_WALLET,
+  DOGE: env.NEXT_PUBLIC_DOGECOIN_WALLET,
+}
+
+export const EXPLORERS: Record<string, string> = {
+  ETH: 'https://etherscan.io/tx/',
+  BTC: 'https://www.blockchain.com/btc/tx/',
+  SOL: 'https://solscan.io/tx/',
+  LTC: 'https://blockchair.com/litecoin/transaction/',
+  DOGE: 'https://blockchair.com/dogecoin/transaction/',
+}


### PR DESCRIPTION
## Summary
- add shared donation constants
- use constants in donate pages

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843ee27470c83229aa38c33534afa13