### PR TITLE
Implement network provider abstraction

### DIFF
--- a/src/lib/constants/blockExplorers.ts
+++ b/src/lib/constants/blockExplorers.ts
@@ -1,8 +1,10 @@
 // lib/constants/blockExplorers.ts
+import { NETWORKS } from '../networks';
+
 export const BLOCK_EXPLORERS: Record<number, string> = {
-  1: 'https://etherscan.io/tx/',        // Ethereum Mainnet
-  137: 'https://polygonscan.com/tx/',   // Polygon Mainnet
-  10: 'https://optimistic.etherscan.io/tx/',
-  42161: 'https://arbiscan.io/tx/',
-  56: 'https://bscscan.com/tx/',        // BNB Smart Chain
+  [NETWORKS.ethereum.chainId]: NETWORKS.ethereum.explorer,
+  [NETWORKS.polygon.chainId]: NETWORKS.polygon.explorer,
+  [NETWORKS.optimism.chainId]: NETWORKS.optimism.explorer,
+  [NETWORKS.arbitrum.chainId]: NETWORKS.arbitrum.explorer,
+  [NETWORKS.bsc.chainId]: NETWORKS.bsc.explorer,
 };

--- a/src/lib/networks/index.ts
+++ b/src/lib/networks/index.ts
@@ -1,0 +1,83 @@
+// src/lib/networks/index.ts
+import {
+  http,
+  type Transport,
+  createPublicClient,
+  type SendTransactionParameters as SendTxParams,
+  type Hash,
+  type Chain,
+} from 'viem';
+import { mainnet, polygon, bsc, arbitrum, optimism } from 'viem/chains';
+
+export interface NetworkProvider {
+  chainId: number;
+  name: string;
+  explorer: string;
+  chain: Chain;
+  getProvider(): Transport;
+  estimateGas(tx: SendTxParams): Promise<bigint>;
+  sendTransaction(tx: SendTxParams): Promise<Hash>;
+}
+
+function createProvider(
+  chain: Chain,
+  name: string,
+  explorer: string,
+  rpcUrl: string,
+): NetworkProvider {
+  const client = createPublicClient({ chain, transport: http(rpcUrl) });
+  return {
+    chainId: chain.id,
+    name,
+    chain,
+    explorer,
+    getProvider: () => client.transport,
+    estimateGas: (tx) => client.estimateGas(tx),
+    sendTransaction: (tx) => client.sendTransaction(tx),
+  };
+}
+
+export const ethereum = createProvider(
+  mainnet,
+  'Ethereum',
+  'https://etherscan.io/tx/',
+  'https://eth.llamarpc.com',
+);
+
+export const polygonProvider = createProvider(
+  polygon,
+  'Polygon',
+  'https://polygonscan.com/tx/',
+  'https://polygon.llamarpc.com',
+);
+
+export const bscProvider = createProvider(
+  bsc,
+  'BNB Smart Chain',
+  'https://bscscan.com/tx/',
+  'https://bsc-dataseed.binance.org',
+);
+
+export const arbitrumProvider = createProvider(
+  arbitrum,
+  'Arbitrum',
+  'https://arbiscan.io/tx/',
+  'https://arbitrum.llamarpc.com',
+);
+
+export const optimismProvider = createProvider(
+  optimism,
+  'Optimism',
+  'https://optimistic.etherscan.io/tx/',
+  'https://optimism.llamarpc.com',
+);
+
+export const NETWORKS = {
+  ethereum,
+  polygon: polygonProvider,
+  bsc: bscProvider,
+  arbitrum: arbitrumProvider,
+  optimism: optimismProvider,
+};
+
+

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,17 +1,24 @@
 // src/lib/wallet.ts
 import { getDefaultConfig } from '@rainbow-me/rainbowkit'
-import { mainnet, polygon, optimism, arbitrum } from 'wagmi/chains'
 import { http } from 'wagmi'
 import { env } from './env'
+import { NETWORKS } from './networks'
 
 export const config = getDefaultConfig({
   appName: 'Dripnex',
   projectId: env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
-  chains: [mainnet, polygon, optimism, arbitrum],
+  chains: [
+    NETWORKS.ethereum.chain,
+    NETWORKS.polygon.chain,
+    NETWORKS.optimism.chain,
+    NETWORKS.arbitrum.chain,
+    NETWORKS.bsc.chain,
+  ],
   transports: {
-    [mainnet.id]: http(),
-    [polygon.id]: http(),
-    [optimism.id]: http(),
-    [arbitrum.id]: http(),
+    [NETWORKS.ethereum.chain.id]: http(),
+    [NETWORKS.polygon.chain.id]: http(),
+    [NETWORKS.optimism.chain.id]: http(),
+    [NETWORKS.arbitrum.chain.id]: http(),
+    [NETWORKS.bsc.chain.id]: http(),
   },
 });


### PR DESCRIPTION
## Summary
- add `NetworkProvider` interface with provider implementations
- expose providers via `NETWORKS`
- reference providers inside wallet configuration
- map `BLOCK_EXPLORERS` using new provider metadata

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684481f250088322973dc618e3a9b54d