### PR TITLE
Add network selection for transactions

### DIFF
--- a/src/app/hooks/useSendTransaction.test.ts
+++ b/src/app/hooks/useSendTransaction.test.ts
@@ -1,0 +1,42 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useSendTransaction } from './useSendTransaction';
+
+const mockSendTransaction = vi.fn((_, { onSuccess }) => {
+  onSuccess('0xtest');
+});
+
+vi.mock('wagmi', () => ({
+  useSendTransaction: () => ({
+    sendTransaction: mockSendTransaction,
+    isPending: false,
+    data: undefined,
+    error: undefined,
+    isError: false,
+  }),
+  useWaitForTransactionReceipt: () => ({
+    isSuccess: true,
+    isLoading: false,
+  }),
+  useEstimateGas: () => ({ data: 100n }),
+  useFeeData: () => ({ data: { gasPrice: 2n } }),
+}));
+
+vi.mock('viem', () => ({
+  parseEther: (v: string) => v,
+  formatEther: (v: bigint) => String(v),
+}));
+
+test('send uses wagmi and updates txHash', () => {
+  const { result } = renderHook(() =>
+    useSendTransaction(1, '0xabc' as `0x${string}`, '1')
+  );
+  act(() => {
+    result.current.send('0xabc' as `0x${string}`, '1');
+  });
+  expect(mockSendTransaction).toHaveBeenCalledWith(
+    { to: '0xabc', value: '1' },
+    expect.objectContaining({ onSuccess: expect.any(Function) })
+  );
+  expect(result.current.txHash).toBe('0xtest');
+});

--- a/src/app/hooks/useSendTransaction.ts
+++ b/src/app/hooks/useSendTransaction.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { parseEther, formatEther } from 'viem';
+import {
+  useSendTransaction as wagmiUseSendTransaction,
+  useWaitForTransactionReceipt,
+  useEstimateGas,
+  useFeeData,
+} from 'wagmi';
+import { useState, useMemo } from 'react';
+
+export function useSendTransaction(
+  chainId: number,
+  to?: `0x${string}`,
+  amount?: string
+) {
+  const [txHash, setTxHash] = useState<`0x${string}` | null>(null);
+
+  const { sendTransaction, isPending, error, isError } = wagmiUseSendTransaction({
+    chainId,
+  });
+
+  const { isSuccess, isLoading: isConfirming } = useWaitForTransactionReceipt({
+    hash: txHash!,
+    chainId,
+    query: { enabled: !!txHash },
+  });
+
+  const { data: gasEstimate } = useEstimateGas({
+    chainId,
+    to,
+    value: amount ? parseEther(amount) : undefined,
+    query: { enabled: !!to && !!amount },
+  });
+
+  const { data: feeData } = useFeeData({ chainId });
+
+  const estimatedFee = useMemo(() => {
+    if (!gasEstimate || !feeData?.gasPrice) return null;
+    return formatEther(gasEstimate * feeData.gasPrice);
+  }, [gasEstimate, feeData]);
+
+  const send = (recipient: `0x${string}`, amt: string) => {
+    sendTransaction(
+      { to: recipient, value: parseEther(amt) },
+      {
+        onSuccess: (hash) => {
+          setTxHash(hash);
+        },
+      }
+    );
+  };
+
+  return {
+    send,
+    isPending,
+    isSuccess,
+    isConfirming,
+    isError,
+    error,
+    txHash,
+    estimatedFee,
+  };
+}


### PR DESCRIPTION
## Summary
- add a `useSendTransaction` hook that can estimate fees and accepts a chain id
- replace `useSendEth` with the new hook in `SendReceivePanel`
- allow network dropdown selection before sending
- show estimated fees, success and error messages
- add unit test for the new hook

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684481f4d8108322bc1202f2dd4d5472