### PR TITLE
Improve transaction feedback

### DIFF
--- a/src/app/hooks/useSendETH.test.ts
+++ b/src/app/hooks/useSendETH.test.ts
@@ -2,16 +2,13 @@ import { renderHook, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { useSendEth } from './useSendETH';
 
-const mockSendTransaction = vi.fn((_, { onSuccess }) => {
-  onSuccess('0xtest');
-});
+const mockSendTransactionAsync = vi.fn(() => Promise.resolve('0xtest'));
 
 vi.mock('wagmi', () => ({
   useAccount: () => ({ address: '0x123' }),
   useSendTransaction: () => ({
-    sendTransaction: mockSendTransaction,
+    sendTransactionAsync: mockSendTransactionAsync,
     isPending: false,
-    data: undefined,
     error: undefined,
     isError: false,
   }),
@@ -25,14 +22,14 @@ vi.mock('viem', () => ({
   parseEther: (v: string) => v,
 }));
 
-test('send calls wagmi and updates txHash', () => {
+test('send calls wagmi and updates txHash', async () => {
   const { result } = renderHook(() => useSendEth());
-  act(() => {
-    result.current.send('0xabc', '1');
+  await act(async () => {
+    await result.current.send('0xabc', '1');
   });
-  expect(mockSendTransaction).toHaveBeenCalledWith(
-    { to: '0xabc', value: '1' },
-    expect.objectContaining({ onSuccess: expect.any(Function) })
-  );
+  expect(mockSendTransactionAsync).toHaveBeenCalledWith({
+    to: '0xabc',
+    value: '1',
+  });
   expect(result.current.txHash).toBe('0xtest');
 });

--- a/src/app/hooks/useSendETH.ts
+++ b/src/app/hooks/useSendETH.ts
@@ -1,15 +1,19 @@
 'use client';
 
 import { parseEther } from 'viem';
-import { useAccount, useSendTransaction, useWaitForTransactionReceipt } from 'wagmi';
-import { useState } from 'react';
+import {
+  useAccount,
+  useSendTransaction,
+  useWaitForTransactionReceipt,
+} from 'wagmi';
+import { useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
 
 export function useSendEth() {
   const [txHash, setTxHash] = useState<`0x${string}` | null>(null);
   const { address } = useAccount();
   const {
-    sendTransaction,
-    data,
+    sendTransactionAsync,
     isPending,
     error,
     isError,
@@ -20,19 +24,26 @@ export function useSendEth() {
     query: { enabled: !!txHash },
   });
 
-  const send = (to: `0x${string}`, amount: string) => {
-    sendTransaction(
-      {
+  const send = async (to: `0x${string}`, amount: string) => {
+    try {
+      const tx = await sendTransactionAsync({
         to,
         value: parseEther(amount),
-      },
-      {
-        onSuccess: (data) => {
-          setTxHash(data);
-        },
-      }
-    );
+      });
+      setTxHash(tx);
+      toast.success('✅ Transaction submitted');
+      return tx;
+    } catch (err) {
+      toast.error('❌ Transaction failed');
+      throw err;
+    }
   };
+
+  useEffect(() => {
+    if (isSuccess) {
+      toast.success('✅ Transaction confirmed');
+    }
+  }, [isSuccess]);
 
   return {
     send,

--- a/src/app/wallet/components/SendReceivePanel.tsx
+++ b/src/app/wallet/components/SendReceivePanel.tsx
@@ -3,6 +3,8 @@ import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { FaRegCopy, FaCheck } from 'react-icons/fa';
 import { useSendEth } from '@/app/hooks/useSendETH';
+import { isAddress } from 'viem';
+import toast from 'react-hot-toast';
 
 type Props = {
   address: string;
@@ -17,7 +19,7 @@ export default function SendReceivePanel({ address }: Props) {
 
   const { send, isPending, isConfirming, txHash } = useSendEth();
 
-  const isValidAddress = recipient.startsWith('0x') && recipient.length === 42;
+  const isValidAddress = isAddress(recipient);
   const suggestedAmounts = ['0.01', '0.05', '0.1', '0.5', '1'];
 
   const handleCopyAddress = () => {
@@ -28,10 +30,17 @@ export default function SendReceivePanel({ address }: Props) {
 
   const handleSend = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isValidAddress) {
+      toast.error('Invalid address for this network');
+      return;
+    }
     try {
       await send(recipient as `0x${string}`, amount);
     } catch (err) {
       console.error('Transaction failed', err);
+      toast.error(
+        err instanceof Error ? err.message : 'Transaction failed'
+      );
     }
   };
 


### PR DESCRIPTION
## Summary
- validate Ethereum addresses using `viem`
- show toast notifications on transaction success and failure
- handle provider errors gracefully
- update tests for new async send logic

## Testing
- `npx vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684481f684f08322b911ebce60615070