### PR TITLE
Add JSDoc across exported modules

### DIFF
--- a/src/app/api/etherscan/route.ts
+++ b/src/app/api/etherscan/route.ts
@@ -5,6 +5,12 @@ import { env } from '@/lib/env'
 const ETHERSCAN_API_KEY = env.ETHERSCAN_API_KEY
 const ETHERSCAN_BASE_URL = 'https://api.etherscan.io/api';
 
+/**
+ * API endpoint that proxies the Etherscan `txlist` API.
+ *
+ * @param request - `Request` containing the wallet `address` query parameter.
+ * @returns JSON response with the list of parsed transactions.
+ */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const address = searchParams.get('address');

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -3,6 +3,12 @@ import { NextResponse } from 'next/server';
 import { subscribeToBrevo } from '@/lib/email';
 import { isRateLimited } from '@/utils/rateLimiter';
 
+/**
+ * Subscribe a user to Brevo while applying rate limiting by IP.
+ *
+ * @param req Incoming POST request with an `email` field.
+ * @returns JSON response describing the result.
+ */
 export async function POST(req: Request) {
   try {
     const ip =

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -16,6 +16,9 @@ const suggestedAmounts = ['0.01', '0.05', '0.1', '0.5', '1'];
 const cryptoOptions = ['ETH', 'BTC', 'SOL', 'LTC', 'DOGE'] as const;
 type CryptoType = typeof cryptoOptions[number];
 
+/**
+ * Donation page allowing supporters to send crypto.
+ */
 export default function DonatePage() {
   const [amount, setAmount] = useState('0.01');
   const [copied, setCopied] = useState(false);

--- a/src/app/hooks/useBrevo.ts
+++ b/src/app/hooks/useBrevo.ts
@@ -2,6 +2,11 @@
 
 import { useState } from 'react';
 
+/**
+ * Handle newsletter subscriptions through the `/api/subscribe` endpoint.
+ *
+ * @returns Object containing the `subscribe` function and loading state.
+ */
 export function useBrevo() {
   const [loading, setLoading] = useState(false);
 

--- a/src/app/hooks/useCurrency.ts
+++ b/src/app/hooks/useCurrency.ts
@@ -1,5 +1,10 @@
 // lib/hooks/useCurrency.ts
 import { useEffect, useState } from 'react';
+/**
+ * Hook that retrieves a list of supported fiat currencies using the CoinGecko API.
+ *
+ * @returns Object containing the currency array and loading state.
+ */
 
 export function useCurrency() {
   const [currencies, setCurrencies] = useState<string[]>([]);

--- a/src/app/hooks/useFiatValue.ts
+++ b/src/app/hooks/useFiatValue.ts
@@ -1,6 +1,13 @@
 // lib/hooks/useFiatValue.ts
 import { useEffect, useState } from 'react';
 
+/**
+ * Convert an ETH amount to the selected fiat currency using CoinGecko.
+ *
+ * @param eth ETH amount.
+ * @param currency Fiat currency code.
+ * @returns Converted value or `null` while loading.
+ */
 export function useFiatValue(eth: number, currency: string) {
   const [fiatValue, setFiatValue] = useState<number | null>(null);
 

--- a/src/app/hooks/usePrevious.ts
+++ b/src/app/hooks/usePrevious.ts
@@ -1,6 +1,12 @@
 // lib/hooks/usePrevious.ts
 import { useEffect, useRef } from 'react';
 
+/**
+ * Persist the previous value of a variable between renders.
+ *
+ * @param value The value to track.
+ * @returns The previous value.
+ */
 export function usePrevious<T>(value: T) {
   const ref = useRef<T>(undefined);
 

--- a/src/app/hooks/usePriceEffects.ts
+++ b/src/app/hooks/usePriceEffects.ts
@@ -5,6 +5,12 @@ interface Coin {
   current_price: number;
 }
 
+/**
+ * Track price movements to apply visual effects on updates.
+ *
+ * @param coins Array of coin objects with `id` and `current_price`.
+ * @returns Effects map and previous prices for each coin.
+ */
 export function usePriceEffects(coins: Coin[]) {
   const previousPricesRef = useRef<{ [id: string]: number }>({});
   const [effects, setEffects] = useState<{ [id: string]: 'pulse' | 'flash-up' | 'flash-down' | null }>({});

--- a/src/app/hooks/useSendETH.ts
+++ b/src/app/hooks/useSendETH.ts
@@ -4,6 +4,11 @@ import { parseEther } from 'viem';
 import { useAccount, useSendTransaction, useWaitForTransactionReceipt } from 'wagmi';
 import { useState } from 'react';
 
+/**
+ * Utility hook to send ETH using `wagmi`'s `useSendTransaction`.
+ *
+ * @returns State and helper methods for sending ETH transactions.
+ */
 export function useSendEth() {
   const [txHash, setTxHash] = useState<`0x${string}` | null>(null);
   const { address } = useAccount();

--- a/src/app/hooks/useTopCoin.ts
+++ b/src/app/hooks/useTopCoin.ts
@@ -12,6 +12,12 @@ interface Coin {
 
 
 
+/**
+ * Retrieve basic market data for top coins from CoinGecko.
+ *
+ * @param vs_currency Currency in which to price the coins.
+ * @returns Coin list and loading state.
+ */
 export function useTopCoins(vs_currency = 'usd') {
   const [coins, setCoins] = useState<Coin[]>([]);
   const [loading, setLoading] = useState(true);

--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -3,6 +3,12 @@ import { useCallback, useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 import { UserProfile } from '@/types/user';
 
+/**
+ * Load a user profile from the `profiles` table using Supabase.
+ *
+ * @param address Wallet address to fetch.
+ * @returns Profile data, loading flag, error message and a refetch function.
+ */
 export function useUserProfile(address?: string) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(false);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,9 @@ import { Web3Wrapper } from "@/components/Web3Wrapper";
 import { Toaster } from 'react-hot-toast';
 
 
+/**
+ * Application root layout used by Next.js.
+ */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,6 +6,9 @@ import { motion } from 'framer-motion';
 import PageLayout from '@/components/PageLayout';
 import './globals.css'; // Ensure global styles are imported
 
+/**
+ * Custom 404 page.
+ */
 export default function NotFoundPage() {
   const router = useRouter();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,9 @@ function SectionDivider() {
   );
 }
 
+/**
+ * Home page composed of several landing sections.
+ */
 export default function Home() {
   return (
     <Web3Wrapper>

--- a/src/app/profile/EditToggle.tsx
+++ b/src/app/profile/EditToggle.tsx
@@ -4,6 +4,11 @@ type Props = {
   onClick: () => void;
 };
 
+/**
+ * Button used to toggle profile editing mode.
+ *
+ * @param props.onClick Called when the button is clicked.
+ */
 export default function EditToggle({ onClick }: Props) {
   return (
     <motion.button

--- a/src/app/profile/ProfileHeader.tsx
+++ b/src/app/profile/ProfileHeader.tsx
@@ -5,6 +5,12 @@ type Props = {
   createdAt: string;
 };
 
+/**
+ * Header displaying user avatar and join date.
+ *
+ * @param props.username Username of the profile.
+ * @param props.createdAt Creation date string.
+ */
 export default function ProfileHeader({ username, createdAt }: Props) {
   const firstLetter = username.charAt(0).toUpperCase();
 

--- a/src/app/wallet/WalletDashboard.tsx
+++ b/src/app/wallet/WalletDashboard.tsx
@@ -10,6 +10,9 @@ import TransactionList from './components/TransactionList';
 import SendReceivePanel from './components/SendReceivePanel';
 import DonateWidget from './components/DonateWidget';
 
+/**
+ * Main dashboard showing wallet info, transactions and donation widget.
+ */
 export default function WalletDashboard() {
   const router = useRouter();
   const { address, isConnected } = useAccount();

--- a/src/app/wallet/components/AmountInput.tsx
+++ b/src/app/wallet/components/AmountInput.tsx
@@ -12,6 +12,13 @@ interface Props {
   setAmount: (val: string) => void;
 }
 
+/**
+ * Input group for selecting a donation amount.
+ *
+ * @param props.selectedCrypto Selected cryptocurrency.
+ * @param props.amount Current amount.
+ * @param props.setAmount Setter for amount.
+ */
 export default function AmountInput({ selectedCrypto, amount, setAmount }: Props) {
   const [amountCopied, setAmountCopied] = useState<string | null>(null);
 

--- a/src/app/wallet/components/CryptoLogos.tsx
+++ b/src/app/wallet/components/CryptoLogos.tsx
@@ -7,6 +7,11 @@ import {
 } from 'react-icons/fa';
 import { SiSolana, SiLitecoin } from 'react-icons/si';
 
+/**
+ * Return an icon component for the given crypto symbol.
+ *
+ * @param symbol Cryptocurrency symbol.
+ */
 export function CryptoLogos({ symbol }: { symbol: string }) {
   const iconProps = { className: 'inline mr-2 text-lg' };
 

--- a/src/app/wallet/components/CryptoSelector.tsx
+++ b/src/app/wallet/components/CryptoSelector.tsx
@@ -12,6 +12,13 @@ interface Props {
   address: string;
 }
 
+/**
+ * Selector for choosing which cryptocurrency to donate with.
+ *
+ * @param props.selectedCrypto Current crypto option.
+ * @param props.setSelectedCrypto Setter for selection.
+ * @param props.address Wallet address to display.
+ */
 export default function CryptoSelector({
   selectedCrypto,
   setSelectedCrypto,

--- a/src/app/wallet/components/DonateWidget.tsx
+++ b/src/app/wallet/components/DonateWidget.tsx
@@ -16,6 +16,14 @@ interface DonateWidgetProps {
   showHeader?: boolean;
 }
 
+/**
+ * Complete donation widget combining selectors and send button.
+ *
+ * @param props.defaultCrypto Default crypto to show.
+ * @param props.title Title shown at top.
+ * @param props.description Optional description text.
+ * @param props.showHeader Whether to display header section.
+ */
 export default function DonateWidget({
   defaultCrypto = 'ETH',
   title = 'Support Dripnex',

--- a/src/app/wallet/components/FiatValue.tsx
+++ b/src/app/wallet/components/FiatValue.tsx
@@ -6,6 +6,12 @@ type Props = {
   currency: string;
 };
 
+/**
+ * Display the fiat value of a given ETH amount.
+ *
+ * @param props.eth Amount in ETH.
+ * @param props.currency Fiat currency code.
+ */
 export default function FiatValue({ eth, currency }: Props) {
   const [price, setPrice] = useState<number | null>(null);
 

--- a/src/app/wallet/components/SendDonation.tsx
+++ b/src/app/wallet/components/SendDonation.tsx
@@ -14,6 +14,14 @@ interface Props {
   explorerBase: string;
 }
 
+/**
+ * Handles sending the donation transaction using wagmi.
+ *
+ * @param props.selectedCrypto Crypto being used.
+ * @param props.amount Amount to send.
+ * @param props.address Destination address.
+ * @param props.explorerBase Explorer base URL for transaction link.
+ */
 export default function SendDonation({
   selectedCrypto,
   amount,

--- a/src/app/wallet/components/SendReceivePanel.tsx
+++ b/src/app/wallet/components/SendReceivePanel.tsx
@@ -8,6 +8,11 @@ type Props = {
   address: string;
 };
 
+/**
+ * Panel for sending ETH or displaying wallet QR for receiving.
+ *
+ * @param props.address Wallet address used for receive tab.
+ */
 export default function SendReceivePanel({ address }: Props) {
   const [activeTab, setActiveTab] = useState<'send' | 'receive'>('send');
   const [recipient, setRecipient] = useState('');

--- a/src/app/wallet/components/TransactionList.tsx
+++ b/src/app/wallet/components/TransactionList.tsx
@@ -9,6 +9,12 @@ type Props = {
   currentAddress: `0x${string}`;
 };
 
+/**
+ * Displays a list of transactions with copy-to-clipboard helpers.
+ *
+ * @param props.transactions Parsed transaction array.
+ * @param props.currentAddress Address used to detect incoming/outgoing.
+ */
 export default function TransactionList({ transactions, currentAddress }: Props) {
   const [copiedHash, setCopiedHash] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -4,6 +4,9 @@ import WalletDashboard from './WalletDashboard';
 import PageLayout from '@/components/PageLayout';
 import { motion } from 'framer-motion';
 
+/**
+ * Wallet management page displaying the dashboard.
+ */
 export default function WalletPage() {
   return (
     <PageLayout>

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -4,6 +4,11 @@ import { motion } from 'framer-motion';
 // import Lottie from 'lottie-react';
 // import web3Animation from '../../public/animations/animation-server.json';
 
+/**
+ * Landing page introduction section.
+ *
+ * @returns Animated hero description of Dripnex.
+ */
 export default function AboutSection() {
   return (
     <section className="pt-16 pb-12 px-6 text-white max-w-4xl mx-auto text-center">

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -2,6 +2,11 @@
 'use client';
 import { ReactNode } from 'react';
 import { Web3Wrapper } from './Web3Wrapper';
+/**
+ * Provides Web3 context for pages that require client-side wallet access.
+ *
+ * @param children React nodes to render within the providers.
+ */
 
 export default function ClientLayout({ children }: { children: ReactNode }) {
   return <Web3Wrapper>{children}</Web3Wrapper>;

--- a/src/components/ContributeSection.tsx
+++ b/src/components/ContributeSection.tsx
@@ -42,6 +42,9 @@ const waysToContribute = [
   },
 ];
 
+/**
+ * Display ways users can contribute to the project.
+ */
 export default function HowToContributeSection() {
   return (
     <section className="py-8 px-6 max-w-6xl mx-auto text-white text-center">

--- a/src/components/CreateProfileForm.tsx
+++ b/src/components/CreateProfileForm.tsx
@@ -3,6 +3,11 @@
 import { useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 
+/**
+ * Simple form for creating a user profile associated with a wallet.
+ *
+ * @param address Wallet address being registered.
+ */
 export default function CreateProfileForm({ address }: { address: string }) {
   const [username, setUserName] = useState('');
   const [email, setEmail] = useState('');

--- a/src/components/CryptoTickerItem.tsx
+++ b/src/components/CryptoTickerItem.tsx
@@ -17,6 +17,14 @@ interface Props {
   effect: 'pulse' | 'flash-up' | 'flash-down' | null;
 }
 
+/**
+ * Display a single cryptocurrency price item within the ticker marquee.
+ *
+ * @param props.coin Coin data.
+ * @param props.currency Currency code used for formatting.
+ * @param props.previous Previous price for change tooltip.
+ * @param props.effect Visual effect to apply on price change.
+ */
 export function CryptoTickerItem({ coin, currency, previous, effect }: Props) {
   const change = coin.price_change_percentage_24h;
   const isUp = change >= 0;

--- a/src/components/CryptoTickerMarquee.tsx
+++ b/src/components/CryptoTickerMarquee.tsx
@@ -5,6 +5,9 @@ import { useTopCoins } from '@/app/hooks/useTopCoin';
 import { usePriceEffects } from '@/app/hooks/usePriceEffects';
 import { CryptoTickerItem } from './CryptoTickerItem';
 
+/**
+ * Scrolling marquee that shows top cryptocurrency prices.
+ */
 export default function CryptoTickerMarquee() {
   const { currency } = useCurrencyStore();
   const { coins, loading } = useTopCoins(currency);

--- a/src/components/CurrencySelector.tsx
+++ b/src/components/CurrencySelector.tsx
@@ -12,6 +12,9 @@ const currencies = [
   { code: 'ars', label: 'ARS', flag: '🇦🇷' },
 ];
 
+/**
+ * Dropdown for selecting the preferred fiat currency.
+ */
 export default function CurrencyDropdown() {
   const { currency, setCurrency } = useCurrencyStore();
   const current = currencies.find((c) => c.code === currency);

--- a/src/components/DarkToggle.tsx
+++ b/src/components/DarkToggle.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useState } from 'react';
 import { FaSun, FaMoon } from 'react-icons/fa';
 
+/**
+ * Toggle between dark and light themes.
+ */
 export default function DarkToggle() {
   const [isDark, setIsDark] = useState(false);
 

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -5,6 +5,9 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { FaPlus, FaMinus } from 'react-icons/fa';
 import { faqs } from '@/data/faqs';
 
+/**
+ * Frequently asked questions accordion component.
+ */
 export default function FAQSection() {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 

--- a/src/components/FallingGridBackground.tsx
+++ b/src/components/FallingGridBackground.tsx
@@ -2,6 +2,9 @@
 
 import Lottie from 'lottie-react';
 import animationData from '../../public/animations/web3-network-4.json';
+/**
+ * Animated background visual using a Lottie animation.
+ */
 export default function Web3Visual() {
   return (
     <div className="relative w-full h-[60vh] flex items-center justify-center overflow-hidden">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,8 @@
 import { FaXTwitter, FaGithub, FaTelegram, FaLinkedin } from 'react-icons/fa6';
 
+/**
+ * Application footer with social links and navigation.
+ */
 export default function Footer() {
   return (
     <footer className="w-full border-t border-white/10 bg-black/30 backdrop-blur-md text-gray-400 text-sm">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,6 +5,9 @@ import { FaGithub } from 'react-icons/fa';
 import Lottie from 'lottie-react';
 import animationData from '../../public/animations/web3-network-4.json';
 
+/**
+ * Main hero section displayed on the home page.
+ */
 export default function Hero() {
   return (
     <section className="relative min-h-screen flex items-center justify-center text-center px-6 overflow-hidden bg-black/20">

--- a/src/components/JoinCommunity.tsx
+++ b/src/components/JoinCommunity.tsx
@@ -22,6 +22,9 @@ const itemVariants = {
   show: { opacity: 1, y: 0 },
 };
 
+/**
+ * Section encouraging users to join the community and newsletter.
+ */
 export default function CommunityBanner() {
   return (
     <motion.section

--- a/src/components/LegalPage.tsx
+++ b/src/components/LegalPage.tsx
@@ -13,6 +13,13 @@ type Props = {
   sections: LegalItem[];
 };
 
+/**
+ * Render a legal document page.
+ *
+ * @param props.title Document title.
+ * @param props.updatedAt Last updated date string.
+ * @param props.sections Array of content sections.
+ */
 export default function LegalPage({ title, updatedAt, sections }: Props) {
   return (
     <PageLayout>

--- a/src/components/Navbar/DropdownDesktop.tsx
+++ b/src/components/Navbar/DropdownDesktop.tsx
@@ -12,6 +12,12 @@ type Props = {
   sections: DropdownSection[];
 };
 
+/**
+ * Desktop navigation dropdown with multiple sections.
+ *
+ * @param props.label Menu label.
+ * @param props.sections Sections of links.
+ */
 export default function DropdownDesktop({ label, sections }: Props) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);

--- a/src/components/Navbar/DropdownMobile.tsx
+++ b/src/components/Navbar/DropdownMobile.tsx
@@ -14,6 +14,13 @@ type Props = {
   onClickItem?: () => void;
 };
 
+/**
+ * Mobile version of the multi-section dropdown menu.
+ *
+ * @param props.label Menu label.
+ * @param props.sections Sections of links.
+ * @param props.onClickItem Callback when an item is clicked.
+ */
 export default function DropdownMobile({ label, sections, onClickItem }: Props) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);

--- a/src/components/Navbar/MoreDropdown.tsx
+++ b/src/components/Navbar/MoreDropdown.tsx
@@ -24,6 +24,12 @@ type MoreDropdownProps = {
   onClickItem?: () => void;
 };
 
+/**
+ * Wrapper component configuring `MultiSectionDropdown` for the "More" menu.
+ *
+ * @param props.isMobile Render a mobile version.
+ * @param props.onClickItem Optional click handler.
+ */
 export default function MoreDropdown({ isMobile = false, onClickItem }: MoreDropdownProps) {
   return (
     <MultiSectionDropdown

--- a/src/components/Navbar/MultiSectionDropdown.tsx
+++ b/src/components/Navbar/MultiSectionDropdown.tsx
@@ -12,6 +12,14 @@ export type MultiSectionDropdownProps = {
   onClickItem?: () => void;
 };
 
+/**
+ * Responsive dropdown that switches between desktop and mobile implementations.
+ *
+ * @param props.label Menu label.
+ * @param props.sections Sections to render.
+ * @param props.isMobile Render mobile version if true.
+ * @param props.onClickItem Optional item click handler.
+ */
 export default function MultiSectionDropdown({
   label,
   sections,

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -15,6 +15,9 @@ const NAV_LINKS = [
   { href: '/wallet', label: 'Wallet' },
 ];
 
+/**
+ * Site navigation with theme toggle and wallet button.
+ */
 export default function Navbar() {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);

--- a/src/components/NewsletterCTA.tsx
+++ b/src/components/NewsletterCTA.tsx
@@ -4,6 +4,9 @@ import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useBrevo } from '@/app/hooks/useBrevo';
 
+/**
+ * Newsletter call-to-action with email subscription form.
+ */
 export default function NewsletterCTA() {
   const { subscribe, loading } = useBrevo();
   const [email, setEmail] = useState('');

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -6,6 +6,11 @@ type Props = {
   children: ReactNode;
 };
 
+/**
+ * Layout component used across pages with navbar and footer.
+ *
+ * @param props.children Page content.
+ */
 export default function PageLayout({ children }: Props) {
   return (
     <div className="flex flex-col min-h-screen bg-black text-white">

--- a/src/components/PartnerStack.tsx
+++ b/src/components/PartnerStack.tsx
@@ -16,6 +16,9 @@ const tech = [
   { name: 'React', icon: SiReact },
 ];
 
+/**
+ * Showcases technologies used in the project.
+ */
 export default function TechStackShowcase() {
   return (
     <section className="relative py-20 px-6 max-w-6xl mx-auto text-white overflow-hidden">

--- a/src/components/RoadmapTimeline.tsx
+++ b/src/components/RoadmapTimeline.tsx
@@ -25,6 +25,9 @@ const roadmap = [
   },
 ];
 
+/**
+ * Vertical timeline showing the product roadmap.
+ */
 export default function RoadmapTimeline() {
   return (
     <section className="py-16 px-6 max-w-5xl mx-auto text-white">

--- a/src/components/SendETHForm.tsx
+++ b/src/components/SendETHForm.tsx
@@ -4,6 +4,9 @@ import { useState } from 'react';
 import { useAccount, useSendTransaction } from 'wagmi';
 import { parseEther } from 'viem';
 
+/**
+ * Form used in early prototypes to send ETH manually.
+ */
 export default function SendETHForm() {
   const { isConnected } = useAccount();
   const [to, setTo] = useState('');

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -4,6 +4,9 @@ const transactions = [
   { type: "out", amount: "-0.2 ETH", address: "0xdef..." },
 ];
 
+/**
+ * Placeholder list of example transactions.
+ */
 export default function TransactionList() {
   return (
     <ul className="space-y-3">

--- a/src/components/UserProfileForm.tsx
+++ b/src/components/UserProfileForm.tsx
@@ -5,6 +5,9 @@ import { useUserProfile } from '@/app/hooks/useUserProfile';
 import { useAccount } from 'wagmi';
 import { supabase } from '@/lib/supabaseClient';
 
+/**
+ * Form that allows a user to update their profile username.
+ */
 export default function UserProfileForm() {
   const { address } = useAccount();
   const { profile, loading } = useUserProfile(address);

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -4,6 +4,9 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { FaWallet } from 'react-icons/fa';
 import Image from 'next/image';
 
+/**
+ * Wrapper around RainbowKit's `ConnectButton.Custom` providing styling.
+ */
 export default function WalletConnectButton() {
   return (
     <ConnectButton.Custom>

--- a/src/components/WalletCard.tsx
+++ b/src/components/WalletCard.tsx
@@ -1,4 +1,7 @@
 // src/components/WalletCard.tsx
+/**
+ * Example wallet card component used in demos.
+ */
 export default function WalletCard() {
   return (
     <div className="bg-gradient-to-br from-black to-gray-900 p-4 border border-cyan-500 rounded-xl shadow-lg hover:shadow-cyan-500/40 transition">

--- a/src/components/Web3Wrapper.tsx
+++ b/src/components/Web3Wrapper.tsx
@@ -10,6 +10,11 @@ import { config } from '@/lib/wallet';
 
 const queryClient = new QueryClient();
 
+/**
+ * Setup Wagmi, React Query and RainbowKit providers.
+ *
+ * @param props.children Components requiring Web3 context.
+ */
 export function Web3Wrapper({ children }: { children: ReactNode }) {
   const [mounted, setMounted] = useState(false);
 

--- a/src/components/ui/CTAButton.tsx
+++ b/src/components/ui/CTAButton.tsx
@@ -11,6 +11,12 @@ type CTAButtonProps = {
   icon?: ReactNode;
 } & HTMLMotionProps<'a'>;
 
+/**
+ * Animated call-to-action button with optional icon.
+ *
+ * @param props.href Destination URL.
+ * @param props.newTab Open in new tab when true.
+ */
 export default function CTAButton({
   children,
   href,

--- a/src/components/ui/Card3D.tsx
+++ b/src/components/ui/Card3D.tsx
@@ -3,6 +3,12 @@
 import { motion, useMotionValue, useTransform } from 'framer-motion';
 import { useRef } from 'react';
 
+/**
+ * Wrapper that applies a subtle 3D tilt effect on hover.
+ *
+ * @param props.children Content inside the card.
+ * @param props.className Optional additional classes.
+ */
 export default function Card3D({
   children,
   className = '',

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,11 @@
 import { env } from './env'
 
+/**
+ * Add an email address to the Brevo contacts list.
+ *
+ * @param email Address to subscribe.
+ * @returns API response body.
+ */
 export async function subscribeToBrevo(email: string) {
   const apiKey = env.BREVO_API_KEY
 

--- a/src/lib/fetchTransactions.ts
+++ b/src/lib/fetchTransactions.ts
@@ -31,6 +31,12 @@ interface ApiResponse {
   error?: string;
 }
 
+/**
+ * Fetch parsed transactions for the given address from the API route.
+ *
+ * @param address Wallet address.
+ * @returns Transaction data or error.
+ */
 export async function fetchTransactions(address: string): Promise<ApiResponse> {
   const res = await fetch(`/api/etherscan?address=${address}`);
   const data = await res.json();

--- a/src/lib/getEthPrice.ts
+++ b/src/lib/getEthPrice.ts
@@ -1,3 +1,8 @@
+/**
+ * Get the current ETH price in USD and ARS from CoinGecko.
+ *
+ * @returns Object with `usd` and `ars` prices.
+ */
 export async function getEthPrice() {
   const res = await fetch(
     'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd,ars'

--- a/src/services/etherscan.ts
+++ b/src/services/etherscan.ts
@@ -4,6 +4,12 @@ import { env } from '@/lib/env'
 
 const ETHERSCAN_BASE_URL = 'https://api.etherscan.io/api'
 
+/**
+ * Fetch transactions from Etherscan directly.
+ *
+ * @param address Wallet address.
+ * @returns Array of transaction objects.
+ */
 export async function getTransactions(address: string) {
   const res = await fetch(
     `${ETHERSCAN_BASE_URL}?module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&sort=desc&apikey=${env.ETHERSCAN_API_KEY}`

--- a/src/utils/loadLegalContent.tsx
+++ b/src/utils/loadLegalContent.tsx
@@ -1,6 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 
+/**
+ * Load legal page content from JSON files in `public/legal`.
+ *
+ * @param file File slug (terms-of-use, privacy-policy or cookies-policy).
+ * @returns Parsed JSON content.
+ */
 export function loadLegalContent(file: 'terms-of-use' | 'privacy-policy' | 'cookies-policy') {
   const filePath = path.join(process.cwd(), 'public', 'legal', `${file}.json`);
   const jsonData = fs.readFileSync(filePath, 'utf-8');

--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -5,6 +5,12 @@ const redis = Redis.fromEnv()
 const WINDOW_SECONDS = 60 * 60 // 1 hour
 const LIMIT = 5
 
+/**
+ * Basic rate limiter using Upstash Redis.
+ *
+ * @param ip Client IP address.
+ * @returns `true` if the rate limit is exceeded.
+ */
 export async function isRateLimited(ip: string): Promise<boolean> {
   const key = `rate_limit:${ip}`
   try {


### PR DESCRIPTION
## Summary
- document hooks like `useCurrency` for typed usage
- add API comments for Etherscan and subscribe routes
- include component usage instructions across the project

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684481ff192c83229c5a804ef1a116c2