### PR TITLE
Use zod validation for API routes

### DIFF
--- a/src/app/api/etherscan/route.ts
+++ b/src/app/api/etherscan/route.ts
@@ -1,6 +1,7 @@
 // src/api/etherscan/route.ts
 import { NextResponse } from 'next/server'
 import { env } from '@/lib/env'
+import { z } from 'zod'
 
 /**
  * Interface representing a transaction item returned by the
@@ -44,12 +45,17 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const address = searchParams.get('address');
 
-  if (!address) {
-    return NextResponse.json({ error: 'Missing wallet address' }, { status: 400 });
-  }
+  const querySchema = z.object({
+    address: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  })
 
-  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
-    return NextResponse.json({ error: 'Invalid address' }, { status: 400 });
+  const parsed = querySchema.safeParse({ address })
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: address ? 'Invalid address' : 'Missing wallet address' },
+      { status: 400 }
+    )
   }
 
   try {


### PR DESCRIPTION
## Summary
- validate `/api/etherscan` query params using zod
- validate `/api/subscribe` email payload using zod

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844caeeb9788322b0aad0bbfc6c3ab6