### PR TITLE
Add security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ npm run dev
 ├── styles/
 │   └── globals.css
 ```
+
+## 🔒 Security
+
+The application sends several security headers defined in `next.config.ts`:
+
+- **Content-Security-Policy** restricts asset loading to the same origin.
+- **X-Frame-Options: DENY** prevents embedding the site in iframes.
+- **X-Content-Type-Options: nosniff** stops MIME type sniffing.
+- **Referrer-Policy: same-origin** only sends referrer info for same-site requests.
+- **X-XSS-Protection: 1; mode=block** enables basic XSS filtering in old browsers.
+
 # 🧠 Dripnex Project Backlog
 
 _Last updated: 2025-06-04_

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,34 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value:
+      "default-src 'self'; " +
+      "script-src 'self'; " +
+      "style-src 'self' 'unsafe-inline'; " +
+      "img-src 'self' https: data:; " +
+      "connect-src 'self' https:; " +
+      "frame-ancestors 'none';",
+  },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'same-origin' },
+  { key: 'X-XSS-Protection', value: '1; mode=block' },
+];
+
 const nextConfig: NextConfig = {
-    reactStrictMode: true,
-    images: {
+  reactStrictMode: true,
+  images: {
     domains: ['coin-images.coingecko.com'],
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
   },
   /* config options here */
 };


### PR DESCRIPTION
## Summary
- define security headers in `next.config.ts`
- apply those headers site-wide
- document headers in new Security section in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844caee50b4832287f0add5da993aff