### PR TITLE
Add multi-wallet profile support

### DIFF
--- a/src/app/profile/EditProfileForm.tsx
+++ b/src/app/profile/EditProfileForm.tsx
@@ -6,9 +6,9 @@ import { motion, AnimatePresence } from 'framer-motion';
 import toast from 'react-hot-toast';
 
 type Profile = {
+  id: string;
   username: string;
   email: string;
-  wallet_address: string;
 };
 
 type Props = {
@@ -33,7 +33,7 @@ export default function EditProfileForm({ profile, onCancel, onSuccess }: Props)
     const { error: updateError } = await supabase
       .from('profiles')
       .update({ username, email })
-      .eq('wallet_address', profile.wallet_address);
+      .eq('id', profile.id);
 
     setSaving(false);
 

--- a/src/app/wallet/components/WalletList.tsx
+++ b/src/app/wallet/components/WalletList.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import { Wallet } from '@/types/user';
+
+interface Props {
+  profileId: string;
+  wallets: Wallet[];
+  onChange: () => void;
+}
+
+/**
+ * Displays a list of wallet addresses with controls to add or remove them.
+ */
+export default function WalletList({ profileId, wallets, onChange }: Props) {
+  const [newAddress, setNewAddress] = useState('');
+  const [adding, setAdding] = useState(false);
+
+  const handleAdd = async () => {
+    if (!newAddress) return;
+    setAdding(true);
+    await supabase.from('wallets').insert({ profile_id: profileId, address: newAddress });
+    setAdding(false);
+    setNewAddress('');
+    onChange();
+  };
+
+  const handleRemove = async (id: string) => {
+    await supabase.from('wallets').delete().eq('id', id);
+    onChange();
+  };
+
+  return (
+    <div className="space-y-4 text-sm text-white">
+      <h3 className="font-semibold">Wallets</h3>
+      <ul className="space-y-2">
+        {wallets.map((w) => (
+          <li key={w.id} className="flex items-center gap-2">
+            <span className="flex-1 break-all text-xs bg-white/10 px-2 py-1 rounded">
+              {w.address}
+            </span>
+            <button
+              onClick={() => handleRemove(w.id)}
+              className="text-red-400 hover:underline"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={newAddress}
+          onChange={(e) => setNewAddress(e.target.value)}
+          className="flex-1 p-1 text-black rounded text-xs"
+          placeholder="New address"
+        />
+        <button
+          onClick={handleAdd}
+          disabled={adding}
+          className="bg-teal-600 text-white px-2 py-1 rounded text-xs disabled:opacity-50"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UserProfileForm.tsx
+++ b/src/components/UserProfileForm.tsx
@@ -16,11 +16,12 @@ export default function UserProfileForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!address) return;
+    if (!profile) return;
 
     const { error } = await supabase
       .from('profiles')
-      .upsert({ wallet_address: address, username }, { onConflict: 'wallet_address' });
+      .update({ username })
+      .eq('id', profile.id);
 
     setMessage(error ? 'Error saving username' : 'Username saved!');
   };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,8 +1,16 @@
+export interface Wallet {
+  id: string;
+  profile_id: string;
+  address: string;
+  chain_id: number | null;
+  created_at: string;
+}
+
 export interface UserProfile {
   id: string;
   username: string;
   email: string;
-  wallet_address: string;
   created_at: string;
   avatar_url?: string;
+  wallets: Wallet[];
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  username text NOT NULL,
+  email text NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  avatar_url text
+);
+
+CREATE TABLE wallets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  address text UNIQUE NOT NULL,
+  chain_id integer,
+  created_at timestamptz DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- allow storing multiple wallets for a profile via `wallets` table
- fetch profile by wallet and include associated wallets
- update create/edit profile forms for new schema
- show wallet list on dashboard with add/remove controls
- document new Supabase tables

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844caf067e88322b3149c2fed886cb8