### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,6 @@ jobs:
         with:
           node-version: 20
       - run: npm install
+      - run: npx playwright install --with-deps
       - run: npm test
+      - run: npm run e2e

--- a/e2e/balance-check.spec.ts
+++ b/e2e/balance-check.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('balance text visible on wallet page', async ({ page }) => {
+  await page.goto('/wallet');
+  await expect(page.getByText(/balance/i)).toBeVisible();
+});

--- a/e2e/network-switch.spec.ts
+++ b/e2e/network-switch.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('network dropdown changes value', async ({ page }) => {
+  await page.goto('/wallet');
+  const select = page.getByRole('combobox');
+  await expect(select).toBeVisible();
+  const options = await select.locator('option').all();
+  if (options.length > 1) {
+    await select.selectOption(options[1]);
+    await expect(select).toHaveValue(await options[1].getAttribute('value'));
+  }
+});

--- a/e2e/token-transfer.spec.ts
+++ b/e2e/token-transfer.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('transfer form validates input', async ({ page }) => {
+  await page.goto('/wallet');
+  await expect(page.getByText('Wallet Center')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Send' })).toBeDisabled();
+});

--- a/e2e/wallet-connection.spec.ts
+++ b/e2e/wallet-connection.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('wallet connect modal opens', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: /connect wallet/i }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@covalenthq/ai-agent-sdk": "^0.3.0",
@@ -48,6 +49,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "jsdom": "^22.1.0",
+    "playwright": "^1.42.1",
     "postcss": "^8.5.4",
     "tailwindcss": "3.4",
     "typescript": "^5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run build && npm start',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Playwright
- add e2e specs covering wallet connect flow, transfer form, balance display and network switch
- run Playwright in CI
- expose `e2e` npm script and dependency

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844caf29cc48322aa1716894f0ea86b