### PR TITLE
Fix path in Dashboard and test rename

### DIFF
--- a/src/features/wallet/Dashboard.tsx
+++ b/src/features/wallet/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 import { NETWORKS } from '@/lib/networks';
-import { useUserProfile } from '../hooks/useUserProfile';
+import { useUserProfile } from '@/app/hooks/useUserProfile';
 import { fetchTransactions, ParsedTransaction } from '@/lib/fetchTransactions';
 import ProfileCard from './components/ProfileCard';
 import TransactionList from './components/TransactionList';

--- a/src/features/wallet/components/__tests__/TransferPanel.test.tsx
+++ b/src/features/wallet/components/__tests__/TransferPanel.test.tsx
@@ -16,7 +16,7 @@ vi.mock('wagmi', () => ({
   useBalance: () => ({ data: { formatted: '0' } }),
 }));
 
-describe('SendReceivePanel', () => {
+describe('TransferPanel', () => {
   it('renders send tab by default', () => {
     const { getByText } = render(<TransferPanel address="0x123" />);
     expect(getByText('Send')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- fix wrong import path for `useUserProfile` in `Dashboard`
- rename `SendReceivePanel` test description to `TransferPanel`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2d716b48322adfceaff9c452cc9