### PR TITLE
Add healthz endpoint and tests

### DIFF
--- a/src/app/api/healthz/route.test.ts
+++ b/src/app/api/healthz/route.test.ts
@@ -1,0 +1,37 @@
+import { vi, describe, it, expect } from 'vitest'
+import { GET } from './route'
+
+// Mock env
+vi.mock('@/lib/env', () => ({ env: { ETHERSCAN_API_KEY: 'test' } }))
+
+// Mock Supabase client
+vi.mock('@/lib/supabaseClient', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        limit: () => Promise.resolve({ data: [], error: null }),
+      }),
+    }),
+  },
+}))
+
+// Mock Upstash Redis
+vi.mock('@upstash/redis', () => ({
+  Redis: {
+    fromEnv: () => ({
+      ping: vi.fn().mockResolvedValue('PONG'),
+    }),
+  },
+}))
+
+// Mock fetch for Etherscan
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)))
+
+describe('GET /api/healthz', () => {
+  it('returns ok when all services respond', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ ok: true })
+  })
+})

--- a/src/app/api/healthz/route.ts
+++ b/src/app/api/healthz/route.ts
@@ -1,0 +1,34 @@
+// src/app/api/healthz/route.ts
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabaseClient'
+import { Redis } from '@upstash/redis'
+import { env } from '@/lib/env'
+
+const redis = Redis.fromEnv()
+
+/**
+ * Liveness and readiness check for external services.
+ */
+export async function GET() {
+  try {
+    // Verify Supabase connectivity via a trivial request
+    const { error: supabaseError } = await supabase.from('profiles').select('id').limit(1)
+    if (supabaseError) {
+      throw supabaseError
+    }
+
+    // Verify Redis connectivity
+    await redis.ping()
+
+    // Verify Etherscan connectivity
+    const url = `https://api.etherscan.io/api?module=stats&action=ethprice&apikey=${env.ETHERSCAN_API_KEY}`
+    const etherscanRes = await fetch(url)
+    if (!etherscanRes.ok) {
+      throw new Error('Etherscan request failed')
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/healthz` endpoint that checks Supabase, Redis and Etherscan
- provide integration test with mocks

## Testing
- `npx vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7caaf308322b22465a5b1cb3e80