### PR TITLE
Add CSRF protection middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ ETHERSCAN_API_KEY=
 # API key for Brevo email service
 BREVO_API_KEY=
 
+# Secret used to sign CSRF tokens
+CSRF_SECRET=
+
 # Donation addresses
 NEXT_PUBLIC_ETH_WALLET=
 NEXT_PUBLIC_BITCOIN_WALLET=

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ addresses. Copy `.env.example` to `.env.local` and fill in your values.
 | `NEXT_PUBLIC_ETHERSCAN_API_KEY` | Public API key for client Etherscan calls |
 | `ETHERSCAN_API_KEY` | Private API key for server-side Etherscan requests |
 | `BREVO_API_KEY` | API key for the Brevo email service |
+| `CSRF_SECRET` | Secret used to sign CSRF tokens |
 | `NEXT_PUBLIC_ETH_WALLET` | Donation address for Ethereum |
 | `NEXT_PUBLIC_BITCOIN_WALLET` | Donation address for Bitcoin |
 | `NEXT_PUBLIC_SOLANA_WALLET` | Donation address for Solana |
@@ -115,6 +116,7 @@ The application sends several security headers defined in `next.config.ts`:
 - **X-Content-Type-Options: nosniff** stops MIME type sniffing.
 - **Referrer-Policy: same-origin** only sends referrer info for same-site requests.
 - **X-XSS-Protection: 1; mode=block** enables basic XSS filtering in old browsers.
+- **CSRF Protection** requires sending the `csrf-token` header with POST requests. The value comes from the `csrfToken` cookie set by the server.
 
 # 🧠 Dripnex Project Backlog
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,7 @@
+import { setupCsrf } from './src/lib/csrf'
+
+export const middleware = setupCsrf()
+
+export const config = {
+  matcher: ['/api/:path*'],
+}

--- a/src/app/api/subscribe/route.test.ts
+++ b/src/app/api/subscribe/route.test.ts
@@ -1,12 +1,28 @@
 import { POST } from './route';
 import { describe, it, expect } from 'vitest';
+import { generateCsrfToken } from '@/lib/csrf';
 
 describe('POST /api/subscribe', () => {
+  it('returns 403 when csrf token is missing', async () => {
+    const req = new Request('http://test.com/api/subscribe', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'test@example.com' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
   it('returns 400 for invalid email', async () => {
+    const { token, signed } = generateCsrfToken();
     const req = new Request('http://test.com/api/subscribe', {
       method: 'POST',
       body: JSON.stringify({ email: 'invalid' }),
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'csrf-token': token,
+        cookie: `csrfToken=${signed}`,
+      },
     });
     const res = await POST(req);
     expect(res.status).toBe(400);

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { subscribeToBrevo } from '@/lib/email';
 import { isRateLimited } from '@/utils/rateLimiter';
+import { csrf } from '@/lib/csrf';
 import { z } from 'zod';
 
 /**
@@ -10,7 +11,7 @@ import { z } from 'zod';
  * @param req Incoming POST request with an `email` field.
  * @returns JSON response describing the result.
  */
-export async function POST(req: Request) {
+export const POST = csrf(async (req: Request) => {
   try {
     const ip =
       req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
@@ -51,4 +52,4 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ message: 'Unknown error' }, { status: 500 });
   }
-}
+});

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -1,0 +1,51 @@
+import { NextResponse, NextRequest } from 'next/server'
+import { randomBytes, createHmac } from 'crypto'
+
+const COOKIE_NAME = 'csrfToken'
+const HEADER_NAME = 'csrf-token'
+const secret = process.env.CSRF_SECRET || 'development'
+
+function sign(token: string) {
+  return createHmac('sha256', secret).update(token).digest('hex')
+}
+
+export function generateCsrfToken() {
+  const token = randomBytes(32).toString('hex')
+  return { token, signed: `${token}.${sign(token)}` }
+}
+
+export function setupCsrf() {
+  return function middleware(req: NextRequest) {
+    const res = NextResponse.next()
+    if (!req.cookies.get(COOKIE_NAME)) {
+      const { signed } = generateCsrfToken()
+      res.cookies.set(COOKIE_NAME, signed, {
+        httpOnly: true,
+        sameSite: 'strict',
+        path: '/',
+      })
+    }
+    return res
+  }
+}
+
+function verify(signed: string | undefined, token: string | null) {
+  if (!signed || !token) return false
+  const [raw, hash] = signed.split('.')
+  return hash === sign(raw) && raw === token
+}
+
+export function csrf<T extends (req: Request) => any>(handler: T) {
+  return async function wrapped(req: Request) {
+    const cookieHeader = req.headers.get('cookie') || ''
+    const match = cookieHeader.match(new RegExp(`${COOKIE_NAME}=([^;]+)`))
+    const signed = match ? match[1] : undefined
+    const token = req.headers.get(HEADER_NAME)
+
+    if (!verify(signed, token)) {
+      return new NextResponse('Invalid CSRF token', { status: 403 })
+    }
+
+    return handler(req)
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -19,6 +19,7 @@ const clientEnvSchema = z.object({
 const serverEnvSchema = z.object({
   ETHERSCAN_API_KEY: z.string(),
   BREVO_API_KEY: z.string(),
+  CSRF_SECRET: z.string(),
 })
 
 // Parse client env inmediatamente (safe)
@@ -45,6 +46,7 @@ export const serverEnv = (() => {
   return serverEnvSchema.parse({
     ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY,
     BREVO_API_KEY: process.env.BREVO_API_KEY,
+    CSRF_SECRET: process.env.CSRF_SECRET,
   })
 })()
 


### PR DESCRIPTION
## Summary
- implement simple CSRF middleware
- apply CSRF validation to `/api/subscribe` route
- provide CSRF utilities for tests
- document CSRF secret and behaviour in README and env example

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7d0bffc832288e4b8bb31c5b112