### PR TITLE
Improve production Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+**/__tests__
+e2e
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM node:20-alpine
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
-CMD ["npm", "start"]
+
+FROM node:20-alpine AS production
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+CMD ["node_modules/.bin/next", "start"]


### PR DESCRIPTION
## Summary
- use multi-stage Dockerfile with builder and production stages
- add `.dockerignore` for smaller build context

## Testing
- `npm ci` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7d445008322a5c7a8f38ef1e236