### PR TITLE
Add Playwright workflow steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,13 @@ jobs:
         - uses: actions/setup-node@v4
           with:
             node-version: 20
+        - name: Cache Playwright browsers
+          uses: actions/cache@v4
+          with:
+            path: ~/.cache/ms-playwright
+            key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+            restore-keys: |
+              ${{ runner.os }}-playwright-
         - name: Cache NPM
           uses: actions/cache@v4
           with:
@@ -25,6 +32,13 @@ jobs:
         - run: npm run lint
         - run: npm run build
         - run: npm test -- --run --reporter=junit --outputFile=vitest-results.xml
+        - run: npm run e2e
+        - name: Upload Playwright Report
+          if: failure()
+          uses: actions/upload-artifact@v4
+          with:
+            name: playwright-report
+            path: playwright-report
         - name: Upload Vitest Results
           uses: actions/upload-artifact@v4
           if: always()


### PR DESCRIPTION
## Summary
- cache browsers so Playwright can reuse them across jobs
- run Playwright end‑to‑end tests
- upload e2e report if tests fail

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*
- `actionlint .github/workflows/test.yml` *(fails: command not found)*
- `act --list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7d57ea48322af95249fe7038346