### PR TITLE
Update docs for docker-compose and environment setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Dripnex
 
-Thank you for helping make **Dripnex** better! This document describes the workflow for submitting changes and the conventions used in the project.
+Thank you for helping make **Dripnex** better! This document describes the workflow for submitting changes and the conventions used in the project. All commits should follow the Conventional Commits style and every pull request should adhere to the guidelines below.
 
 ## Pull Request Workflow
 
@@ -9,6 +9,7 @@ Thank you for helping make **Dripnex** better! This document describes the workf
 3. Commit your work following the commit style described below.
 4. Push the branch to your fork and open a Pull Request against `main`.
 5. One of the maintainers will review your PR. Please respond to any feedback and update your branch as needed.
+6. Include a concise description of the change and link to any related issues in the PR body.
 
 ## Commit Style
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ addresses. Copy `.env.example` to `.env.local` and fill in your values.
 | `NEXT_PUBLIC_SOLANA_WALLET` | Donation address for Solana |
 | `NEXT_PUBLIC_LITECOIN_WALLET` | Donation address for Litecoin |
 | `NEXT_PUBLIC_DOGECOIN_WALLET` | Donation address for Dogecoin |
+| `UPSTASH_REDIS_REST_URL` | Optional Redis REST endpoint used in Docker |
+| `UPSTASH_REDIS_REST_TOKEN` | Token for the Upstash REST API |
 
 Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser.
+
+Create a `.env.local` file with these values for local development and Docker.
+Tests load variables from `.env.test` using the same keys.
 
 ## 🐳 Docker Usage
 
@@ -65,6 +70,16 @@ docker run --env-file .env.local -p 3000:3000 dripnex
 
 The server will be available at `http://localhost:3000`.
 
+### Docker Compose
+
+If you want Supabase and Redis alongside the app, start everything with:
+
+```bash
+docker-compose up
+```
+
+`docker-compose` reads the same `.env.local` file used for local development.
+
 ## 🧪 Running Tests
 
 1. Install dependencies if you haven't already:
@@ -73,7 +88,7 @@ The server will be available at `http://localhost:3000`.
    npm install
    ```
 
-2. Create a `.env.test` file with the environment variables required for tests. You can copy from `.env.example` and adjust the values as needed.
+2. Create a `.env.test` file with the same keys listed above. The tests will load this file automatically.
 
 3. Execute the test suite with:
 
@@ -115,6 +130,8 @@ The application sends several security headers defined in `next.config.ts`:
 - **X-Content-Type-Options: nosniff** stops MIME type sniffing.
 - **Referrer-Policy: same-origin** only sends referrer info for same-site requests.
 - **X-XSS-Protection: 1; mode=block** enables basic XSS filtering in old browsers.
+
+The API provides a `/healthz` endpoint for health checks. All POST routes require a `csrfToken` header to mitigate CSRF attacks.
 
 # 🧠 Dripnex Project Backlog
 


### PR DESCRIPTION
## Summary
- document Docker Compose workflow
- clarify env vars for Docker and tests
- link commit style and PR guidelines in CONTRIBUTING
- mention new `/healthz` endpoint and CSRF token usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ea453b608322aa4e9c47625369fa