### PR TITLE
Update docs for Docker and API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ Thank you for helping make **Dripnex** better! This document describes the workf
 1. **Fork** the repository and create a new branch off of `main`.
 2. Make your changes and ensure that `npm test` and `npm run lint` run without errors.
 3. Commit your work following the commit style described below.
-4. Push the branch to your fork and open a Pull Request against `main`.
+4. Push the branch to your fork and open a Pull Request against `main`. Use a
+   descriptive title and include a short summary of the changes.
 5. One of the maintainers will review your PR. Please respond to any feedback and update your branch as needed.
 
 ## Commit Style
@@ -24,6 +25,13 @@ A typical commit message looks like:
 ```
 feat: add support for additional networks
 ```
+
+## Pull Request Guidelines
+
+- Use a descriptive title and summary for your PR.
+- Reference any related issues by number.
+- Keep changes focused; open separate PRs for unrelated work.
+- Ensure `npm test` and `npm run lint` pass before requesting review.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ addresses. Copy `.env.example` to `.env.local` and fill in your values.
 | `NEXT_PUBLIC_SOLANA_WALLET` | Donation address for Solana |
 | `NEXT_PUBLIC_LITECOIN_WALLET` | Donation address for Litecoin |
 | `NEXT_PUBLIC_DOGECOIN_WALLET` | Donation address for Dogecoin |
+| `UPSTASH_REDIS_REST_URL` | URL for Upstash Redis REST API *(optional)* |
+| `UPSTASH_REDIS_REST_TOKEN` | Token for Upstash Redis REST API *(optional)* |
 
 Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser.
+
+Docker and `docker-compose` read variables from `.env.local`. The test suite
+uses `.env.test`. Copy `.env.example` to these files and adjust the values for
+your environment.
 
 ## 🐳 Docker Usage
 
@@ -64,6 +70,17 @@ docker run --env-file .env.local -p 3000:3000 dripnex
 ```
 
 The server will be available at `http://localhost:3000`.
+
+### Docker Compose
+
+If you want to run Supabase and Redis along with the app, start all services
+with:
+
+```bash
+docker-compose up
+```
+
+This reads variables from `.env.local` and sets up the required containers.
 
 ## 🧪 Running Tests
 
@@ -115,6 +132,12 @@ The application sends several security headers defined in `next.config.ts`:
 - **X-Content-Type-Options: nosniff** stops MIME type sniffing.
 - **Referrer-Policy: same-origin** only sends referrer info for same-site requests.
 - **X-XSS-Protection: 1; mode=block** enables basic XSS filtering in old browsers.
+
+## API
+
+- **GET `/healthz`** — returns `200 OK` when the server is running.
+- All POST requests require a CSRF token. The token is stored in the
+  `_dripnex_csrf` cookie and must be sent using the `X-CSRF-Token` header.
 
 # 🧠 Dripnex Project Backlog
 


### PR DESCRIPTION
## Summary
- document Upstash variables and note `.env.local` / `.env.test`
- add docker-compose instructions
- mention `/healthz` endpoint and CSRF token header
- expand contributing guide with PR guidelines

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ea52864083229412d1aa2c3a6feb