### PR TITLE
Adjust CSP for Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ docker-compose up
 
 The application sends several security headers defined in `next.config.ts`:
 
-- **Content-Security-Policy** restricts asset loading to the same origin.
+- **Content-Security-Policy** restricts asset loading to the same origin while
+  allowing inline scripts required by Next.js.
 - **X-Frame-Options: DENY** prevents embedding the site in iframes.
 - **X-Content-Type-Options: nosniff** stops MIME type sniffing.
 - **Referrer-Policy: same-origin** only sends referrer info for same-site requests.

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value:
       "default-src 'self'; " +
-      "script-src 'self'; " +
+      "script-src 'self' 'unsafe-inline'; " +
       "style-src 'self' 'unsafe-inline'; " +
       "img-src 'self' https: data:; " +
       "connect-src 'self' https:; " +


### PR DESCRIPTION
## Summary
- allow inline scripts in the Content Security Policy
- document the inline script allowance in the README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f38f31d0832280588b28416bffd3