### PR TITLE
Implement dynamic CSP in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 // src/middleware.ts
 import type { NextRequest } from 'next/server'
+import { randomBytes } from 'crypto'
 import { setupCsrf } from './src/lib/csrf'
 
 const csrfMiddleware = setupCsrf()
@@ -7,12 +8,13 @@ const csrfMiddleware = setupCsrf()
 export function middleware(req: NextRequest) {
   const res = csrfMiddleware(req)
 
-  // Dynamic CSP depending on environment
+  const isDev = process.env.NODE_ENV !== 'production'
+  const nonce = isDev ? '' : randomBytes(16).toString('base64')
 
   const csp = `
     default-src 'self';
-    script-src 'self' 'unsafe-inline' https:;
-    style-src 'self' 'unsafe-inline' https:;
+    script-src 'self' ${isDev ? "'unsafe-inline'" : `'nonce-${nonce}'`} https:;
+    style-src 'self' ${isDev ? "'unsafe-inline'" : ''} https:;
     img-src * blob: data:;
     connect-src *;
     font-src 'self' https: data:;
@@ -21,10 +23,11 @@ export function middleware(req: NextRequest) {
   `.replace(/\s{2,}/g, ' ').trim()
 
   res.headers.set('Content-Security-Policy', csp)
+  if (!isDev) res.headers.set('x-nonce', nonce)
 
   return res
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/api/:path*', '/', '/wallet', '/profile', '/about'],
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,6 @@
 import type { NextConfig } from "next";
 
 const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value:
-      "default-src 'self'; " +
-      "script-src 'self' 'unsafe-inline'; " +
-      "style-src 'self' 'unsafe-inline'; " +
-      "img-src 'self' https: data:; " +
-      "connect-src 'self' https:; " +
-      "frame-ancestors 'none';",
-  },
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'same-origin' },


### PR DESCRIPTION
## Summary
- remove CSP header from `next.config.ts`
- generate CSP dynamically via middleware
- use strict matchers for middleware routing

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*
- `npm run e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f7ce8ecc8322859bfa40e45afade