### PR TITLE
Improve CSP with nonce in middleware

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,6 @@
 import type { NextConfig } from "next";
 
 const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value:
-      "default-src 'self'; " +
-      "script-src 'self' 'unsafe-inline'; " +
-      "style-src 'self' 'unsafe-inline'; " +
-      "img-src 'self' https: data:; " +
-      "connect-src 'self' https:; " +
-      "frame-ancestors 'none';",
-  },
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'same-origin' },


### PR DESCRIPTION
## Summary
- generate nonce in middleware to use with CSP
- set `X-Nonce` header for pages
- only allow `'unsafe-inline'` scripts during development
- update middleware matcher list
- remove static CSP header from `next.config.ts`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8875ee88322a858d393cea56ec5