### PR TITLE
Add secure cookie flag for CSRF

### DIFF
--- a/src/lib/csrf.middleware.test.ts
+++ b/src/lib/csrf.middleware.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { setupCsrf } from './csrf'
+import { NextRequest } from 'next/server'
+
+const URL = 'https://example.com/'
+
+let originalEnv: string | undefined
+
+beforeEach(() => {
+  originalEnv = process.env.NODE_ENV
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+})
+
+describe('setupCsrf middleware', () => {
+  it('sets secure flag when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production'
+    const middleware = setupCsrf()
+    const req = new NextRequest(URL)
+    const res = middleware(req)
+    const cookie = res.cookies.get('csrfToken')
+    expect(cookie?.value).toBeDefined()
+    expect(cookie?.options.secure).toBe(true)
+  })
+
+  it('does not set secure flag when NODE_ENV is not production', () => {
+    process.env.NODE_ENV = 'development'
+    const middleware = setupCsrf()
+    const req = new NextRequest(URL)
+    const res = middleware(req)
+    const cookie = res.cookies.get('csrfToken')
+    expect(cookie?.options.secure).toBe(false)
+  })
+})

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -23,6 +23,7 @@ export function setupCsrf() {
         httpOnly: true,
         sameSite: 'strict',
         path: '/',
+        secure: process.env.NODE_ENV === 'production',
       })
     }
     return res


### PR DESCRIPTION
## Summary
- secure CSRF cookie when running in production
- add coverage for CSRF middleware options

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845177fbf6c8322a93ff4a8799fecf4