### PR TITLE
feat: unify csp directives

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,24 +1,14 @@
 // middleware.ts
 import type { NextRequest } from 'next/server'
 import { setupCsrf } from './src/lib/csrf'
+import { buildCsp } from './src/lib/csp'
 
 const csrfMiddleware = setupCsrf()
 
 export function middleware(req: NextRequest) {
   const res = csrfMiddleware(req)
-
-  const csp = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https:",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src * blob: data:",
-    "connect-src 'self' https:",
-    "font-src 'self' https://fonts.gstatic.com data:",
-    "object-src 'none'",
-    "frame-ancestors 'none'",
-  ].join('; ')
-
-  res.headers.set('Content-Security-Policy', csp)
+  const nonce = req.headers.get('x-nonce') || undefined
+  res.headers.set('Content-Security-Policy', buildCsp(nonce))
   return res
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,17 +1,10 @@
 import type { NextConfig } from "next";
+import { buildCsp } from "./src/lib/csp";
 
 const securityHeaders = [
   {
     key: 'Content-Security-Policy',
-    value: [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "img-src 'self' https: data:",
-      "connect-src 'self' https: ws:",
-      "font-src 'self' https://fonts.gstatic.com data:",
-      "frame-ancestors 'none'",
-    ].join('; '),
+    value: buildCsp(),
   },
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,16 @@
 import { Web3Wrapper } from "@/components/Web3Wrapper";
 import { Toaster } from 'react-hot-toast';
+import { headers } from 'next/headers';
 
 
 /**
  * Application root layout used by Next.js.
  */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const nonce = headers().get('x-nonce') || undefined;
   return (
     <html lang="en">
-      <body>
+      <body nonce={nonce}>
         <Web3Wrapper>
           <Toaster position="top-right" />
 

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,18 @@
+export const walletConnectHosts = [
+  'https://relay.walletconnect.com',
+  'https://*.walletconnect.com',
+];
+
+export function buildCsp(nonce?: string) {
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self'${nonce ? ` 'nonce-${nonce}'` : ''}`,
+    "style-src 'self' https://fonts.googleapis.com",
+    "img-src * blob: data:",
+    `connect-src 'self' https: wss: ${walletConnectHosts.join(' ')}`,
+    "font-src 'self' https://fonts.gstatic.com data:",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+  ];
+  return directives.join('; ');
+}


### PR DESCRIPTION
## Summary
- centralize CSP rules in a shared helper
- generate headers from the helper in middleware and Next.js config
- read nonce value in layout to avoid using unsafe-inline

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684517818b648322b1773ec25a8518ac