### PR TITLE
Add recommended security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ The application sends several security headers defined in `next.config.ts`:
 - **X-Content-Type-Options: nosniff** stops MIME type sniffing.
 - **Referrer-Policy: same-origin** only sends referrer info for same-site requests.
 - **X-XSS-Protection: 1; mode=block** enables basic XSS filtering in old browsers.
+- **Strict-Transport-Security** forces HTTPS connections for two years.
+- **Permissions-Policy** disables unused browser features like camera and microphone.
+- **Cross-Origin-Embedder-Policy: require-corp** enables cross-origin isolation.
+- **Cross-Origin-Resource-Policy: same-origin** restricts where resources can be loaded from.
+- **Cross-Origin-Opener-Policy: same-origin** isolates the browsing context.
 - **CSRF Protection** requires sending the `csrf-token` header with POST requests. The value comes from the `csrfToken` cookie set by the server.
 
 ## API

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,26 @@ const securityHeaders = [
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'same-origin' },
   { key: 'X-XSS-Protection', value: '1; mode=block' },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+  {
+    key: 'Cross-Origin-Embedder-Policy',
+    value: 'require-corp',
+  },
+  {
+    key: 'Cross-Origin-Resource-Policy',
+    value: 'same-origin',
+  },
+  {
+    key: 'Cross-Origin-Opener-Policy',
+    value: 'same-origin',
+  },
 ];
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary
- add recommended security headers in `next.config.ts`
- document headers in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684517838ec88322a5934c5debad9d9a