### PR TITLE
Centralize security headers middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ docker-compose up
 
 ## 🔒 Security
 
-The application sends several security headers defined in `next.config.ts`:
+The application sends several security headers via middleware (`src/middleware/securityHeaders.ts`):
 
   - **Content-Security-Policy** restricts asset loading to the same origin while
   allowing inline scripts required by Next.js.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,24 +1,13 @@
 // middleware.ts
 import type { NextRequest } from 'next/server'
 import { setupCsrf } from './src/lib/csrf'
+import { setSecurityHeaders } from './src/middleware/securityHeaders'
 
 const csrfMiddleware = setupCsrf()
 
 export function middleware(req: NextRequest) {
   const res = csrfMiddleware(req)
-
-  const csp = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https:",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src * blob: data:",
-    "connect-src 'self' https:",
-    "font-src 'self' https://fonts.gstatic.com data:",
-    "object-src 'none'",
-    "frame-ancestors 'none'",
-  ].join('; ')
-
-  res.headers.set('Content-Security-Policy', csp)
+  setSecurityHeaders(res)
   return res
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,36 +1,9 @@
 import type { NextConfig } from "next";
 
-const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "img-src 'self' https: data:",
-      "connect-src 'self' https: ws:",
-      "font-src 'self' https://fonts.gstatic.com data:",
-      "frame-ancestors 'none'",
-    ].join('; '),
-  },
-  { key: 'X-Frame-Options', value: 'DENY' },
-  { key: 'X-Content-Type-Options', value: 'nosniff' },
-  { key: 'Referrer-Policy', value: 'same-origin' },
-  { key: 'X-XSS-Protection', value: '1; mode=block' },
-];
-
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   images: {
     domains: ['coin-images.coingecko.com'],
-  },
-  async headers() {
-    return [
-      {
-        source: '/(.*)',
-        headers: securityHeaders,
-      },
-    ];
   },
   /* config options here */
 };

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+
+export function setSecurityHeaders(res: NextResponse) {
+  const csp = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' https:",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "img-src * blob: data:",
+    "connect-src 'self' https:",    
+    "font-src 'self' https://fonts.gstatic.com data:",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+  ].join('; ')
+
+  res.headers.set('Content-Security-Policy', csp)
+  res.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload')
+  res.headers.set('Referrer-Policy', 'same-origin')
+  res.headers.set('X-Frame-Options', 'DENY')
+  res.headers.set('X-Content-Type-Options', 'nosniff')
+  res.headers.set('X-XSS-Protection', '1; mode=block')
+  res.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()')
+  return res
+}


### PR DESCRIPTION
## Summary
- add middleware for security headers
- remove headers from `next.config.ts`
- apply new middleware in main `middleware.ts`
- update documentation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684518e36da0832283be1d3e61b2ab04