### PR TITLE
Implement ETH price caching

### DIFF
--- a/src/lib/getEthPrice.ts
+++ b/src/lib/getEthPrice.ts
@@ -3,14 +3,35 @@
  *
  * @returns Object with `usd` and `ars` prices.
  */
+declare global {
+  // eslint-disable-next-line no-var
+  var _ethPriceCache:
+    | { value: { usd: number; ars: number }; timestamp: number }
+    | undefined;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
 export async function getEthPrice() {
+  const cached = globalThis._ethPriceCache;
+  const now = Date.now();
+
+  if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+    return cached.value;
+  }
+
   const res = await fetch(
     'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd,ars'
   );
   if (!res.ok) throw new Error('Error fetching ETH price');
   const data = await res.json();
-  return {
+
+  const price = {
     usd: data.ethereum.usd,
     ars: data.ethereum.ars,
   };
+
+  globalThis._ethPriceCache = { value: price, timestamp: now };
+
+  return price;
 }


### PR DESCRIPTION
## Summary
- add a simple in-memory cache with 5 minute TTL for `getEthPrice`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684518ef7fdc8322b31bcfa0432015db