### PR TITLE
Add ERC20 transfer hook

### DIFF
--- a/src/app/hooks/useSendToken.ts
+++ b/src/app/hooks/useSendToken.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { erc20Abi, parseUnits } from 'viem';
+import { useState } from 'react';
+import { useWaitForTransactionReceipt } from 'wagmi';
+import { writeContract } from 'wagmi/actions';
+
+/**
+ * Hook to transfer ERC20 tokens using wagmi's `writeContract`.
+ *
+ * @param chainId Target network chain ID.
+ */
+export function useSendToken(chainId: number) {
+  const [hash, setHash] = useState<`0x${string}` | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({
+    hash: hash!,
+    chainId,
+    query: { enabled: !!hash },
+  });
+
+  const send = async (
+    token: `0x${string}`,
+    to: `0x${string}`,
+    amount: string,
+    decimals: number,
+  ) => {
+    setError(null);
+    setIsPending(true);
+    try {
+      const txHash = await writeContract({
+        chainId,
+        address: token,
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [to, parseUnits(amount, decimals)],
+      });
+      setHash(txHash);
+      return txHash;
+    } catch (err) {
+      setError(err as Error);
+      throw err;
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return { send, hash, isConfirming, isSuccess, isPending, error, isError: !!error };
+}

--- a/src/features/wallet/components/__tests__/TransferPanel.test.tsx
+++ b/src/features/wallet/components/__tests__/TransferPanel.test.tsx
@@ -12,6 +12,15 @@ vi.mock('@/app/hooks/useSendTransaction', () => ({
   }),
 }));
 
+vi.mock('@/app/hooks/useSendToken', () => ({
+  useSendToken: () => ({
+    send: vi.fn(() => Promise.resolve('0xtest')),
+    hash: '0xtest',
+    isPending: false,
+    isConfirming: false,
+  }),
+}));
+
 vi.mock('wagmi', () => ({
   useBalance: () => ({ data: { formatted: '0' } }),
 }));


### PR DESCRIPTION
## Summary
- add `useSendToken` hook built around `writeContract`
- switch `TransferPanel` to use the new hook when a token is selected
- parse token amount using token decimals
- update unit test mocks

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68451b13b37083229d046dbf6ebba5eb