### PR TITLE
Add cache for CoinGecko price

### DIFF
--- a/src/lib/getEthPrice.ts
+++ b/src/lib/getEthPrice.ts
@@ -3,14 +3,28 @@
  *
  * @returns Object with `usd` and `ars` prices.
  */
+let cachedPrice: { usd: number; ars: number } | null = null;
+let cachedAt = 0;
+
+export function invalidateEthPriceCache() {
+  cachedPrice = null;
+  cachedAt = 0;
+}
+
 export async function getEthPrice() {
+  if (cachedPrice && Date.now() - cachedAt < 5 * 60_000) {
+    return cachedPrice;
+  }
+
   const res = await fetch(
     'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd,ars'
   );
   if (!res.ok) throw new Error('Error fetching ETH price');
   const data = await res.json();
-  return {
+  cachedPrice = {
     usd: data.ethereum.usd,
     ars: data.ethereum.ars,
   };
+  cachedAt = Date.now();
+  return cachedPrice;
 }


### PR DESCRIPTION
## Summary
- cache CoinGecko ETH price for 5 minutes
- export helper to invalidate the cache

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451b2581e48322bb2ea45e7ee2e73c