### PR TITLE
Add contacts functionality

### DIFF
--- a/src/app/hooks/useUserProfile.ts
+++ b/src/app/hooks/useUserProfile.ts
@@ -25,7 +25,7 @@ export function useUserProfile(address?: string) {
     try {
       const { data, error: profileErr } = await supabase
         .from('profiles')
-        .select('*, wallets(id, address, chain_id, created_at)')
+        .select('*, wallets(id, address, chain_id, created_at), contacts(id, address, name, created_at)')
         .eq('wallets.address', address)
         .maybeSingle();
 

--- a/src/features/wallet/Dashboard.tsx
+++ b/src/features/wallet/Dashboard.tsx
@@ -11,6 +11,7 @@ import TransactionList from './components/TransactionList';
 import TransferPanel from './components/TransferPanel';
 import DonateWidget from './components/DonateWidget';
 import WalletList from './components/WalletList';
+import ContactList from './components/ContactList';
 
 function TokenBalance({
   address,
@@ -82,8 +83,9 @@ export default function Dashboard() {
 
 
         {profile && (
-          <div className="mt-6">
+          <div className="mt-6 space-y-6">
             <WalletList profileId={profile.id} wallets={profile.wallets} onChange={refetch} />
+            <ContactList profileId={profile.id} contacts={profile.contacts} onChange={refetch} />
           </div>
         )}
 
@@ -118,7 +120,7 @@ export default function Dashboard() {
         </div>
       </div>
 
-      <TransferPanel address={address} />
+      <TransferPanel address={address} contacts={profile?.contacts ?? []} />
     </div>
     <DonateWidget />
     </>

--- a/src/features/wallet/components/ContactList.tsx
+++ b/src/features/wallet/components/ContactList.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import { Contact } from '@/types/user';
+
+interface Props {
+  profileId: string;
+  contacts: Contact[];
+  onChange: () => void;
+}
+
+/**
+ * Displays and manages a list of saved contacts.
+ */
+export default function ContactList({ profileId, contacts, onChange }: Props) {
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState('');
+  const [adding, setAdding] = useState(false);
+
+  const handleAdd = async () => {
+    if (!address) return;
+    setAdding(true);
+    await supabase
+      .from('contacts')
+      .insert({ profile_id: profileId, address, name });
+    setAdding(false);
+    setName('');
+    setAddress('');
+    onChange();
+  };
+
+  const handleRemove = async (id: string) => {
+    await supabase.from('contacts').delete().eq('id', id);
+    onChange();
+  };
+
+  return (
+    <div className="space-y-4 text-sm text-white">
+      <h3 className="font-semibold">Contacts</h3>
+      <ul className="space-y-2">
+        {contacts.map((c) => (
+          <li key={c.id} className="flex items-center gap-2">
+            <span className="flex-1 break-all text-xs bg-white/10 px-2 py-1 rounded">
+              {c.name ? `${c.name} - ${c.address}` : c.address}
+            </span>
+            <button
+              onClick={() => handleRemove(c.id)}
+              className="text-red-400 hover:underline"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex flex-col gap-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="p-1 text-black rounded text-xs"
+          placeholder="Name (optional)"
+        />
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            className="flex-1 p-1 text-black rounded text-xs"
+            placeholder="0x..."
+          />
+          <button
+            onClick={handleAdd}
+            disabled={adding}
+            className="bg-teal-600 text-white px-2 py-1 rounded text-xs disabled:opacity-50"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/wallet/components/ContactSelector.tsx
+++ b/src/features/wallet/components/ContactSelector.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Contact } from '@/types/user';
+
+interface Props {
+  contacts: Contact[];
+  onSelect: (address: string) => void;
+}
+
+/**
+ * Dropdown to choose a saved contact.
+ */
+export default function ContactSelector({ contacts, onSelect }: Props) {
+  return (
+    <select
+      onChange={(e) => onSelect(e.target.value)}
+      className="w-full px-3 py-2 bg-gray-900 border border-white/10 rounded-md text-white text-sm"
+      defaultValue=""
+    >
+      <option value="" disabled>
+        Select contact
+      </option>
+      {contacts.map((c) => (
+        <option key={c.id} value={c.address}>
+          {c.name ? `${c.name} - ${c.address}` : c.address}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/features/wallet/components/TransferPanel.tsx
+++ b/src/features/wallet/components/TransferPanel.tsx
@@ -5,9 +5,12 @@ import { motion } from 'framer-motion';
 import { FaRegCopy, FaCheck } from 'react-icons/fa';
 import { NETWORKS } from '@/lib/networks';
 import { useSendTransactionWithGas } from '@/app/hooks/useSendTransaction';
+import ContactSelector from './ContactSelector';
+import { Contact } from '@/types/user';
 
 type Props = {
   address: string;
+  contacts: Contact[];
 };
 
 /**
@@ -15,7 +18,7 @@ type Props = {
  *
  * @param props.address Wallet address used for receive tab.
  */
-export default function TransferPanel({ address }: Props) {
+export default function TransferPanel({ address, contacts }: Props) {
   const [activeTab, setActiveTab] = useState<'send' | 'receive'>('send');
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
@@ -141,6 +144,12 @@ export default function TransferPanel({ address }: Props) {
             )}
           </div>
           {/* Recipient */}
+          {contacts.length > 0 && (
+            <div>
+              <label className="block text-gray-400 mb-1">Contact</label>
+              <ContactSelector contacts={contacts} onSelect={setRecipient} />
+            </div>
+          )}
           <div>
             <label className="block text-gray-400 mb-1">Recipient Address</label>
             <input

--- a/src/features/wallet/components/__tests__/TransferPanel.test.tsx
+++ b/src/features/wallet/components/__tests__/TransferPanel.test.tsx
@@ -18,7 +18,9 @@ vi.mock('wagmi', () => ({
 
 describe('TransferPanel', () => {
   it('renders send tab by default', () => {
-    const { getByText } = render(<TransferPanel address="0x123" />);
+    const { getByText } = render(
+      <TransferPanel address="0x123" contacts={[]} />
+    );
     expect(getByText('Send')).toBeInTheDocument();
   });
 });

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -6,6 +6,14 @@ export interface Wallet {
   created_at: string;
 }
 
+export interface Contact {
+  id: string;
+  profile_id: string;
+  address: string;
+  name: string | null;
+  created_at: string;
+}
+
 export interface UserProfile {
   id: string;
   username: string;
@@ -13,4 +21,5 @@ export interface UserProfile {
   created_at: string;
   avatar_url?: string;
   wallets: Wallet[];
+  contacts: Contact[];
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -13,3 +13,11 @@ CREATE TABLE wallets (
   chain_id integer,
   created_at timestamptz DEFAULT now()
 );
+
+CREATE TABLE contacts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  address text NOT NULL,
+  name text,
+  created_at timestamptz DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- create `contacts` table in schema
- support contacts in profile types and hook
- list and manage contacts in dashboard
- select contacts when sending tokens

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451b3611bc83229e0d946d9f7e2e81