### PR TITLE
Add NFT gallery

### DIFF
--- a/src/app/api/nfts/route.test.ts
+++ b/src/app/api/nfts/route.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from './route';
+
+describe('GET /api/nfts', () => {
+  it('returns 400 when address is missing', async () => {
+    const res = await GET(new Request('http://test.com/api/nfts'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Missing wallet address' });
+  });
+
+  it('returns 400 for invalid address', async () => {
+    const res = await GET(new Request('http://test.com/api/nfts?address=bad'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Invalid address' });
+  });
+});

--- a/src/app/api/nfts/route.ts
+++ b/src/app/api/nfts/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { env } from '@/lib/env';
+import { z } from 'zod';
+
+/**
+ * API endpoint to fetch NFTs owned by a wallet using the Alchemy NFT API.
+ *
+ * Query params:
+ * - address: wallet address to fetch NFTs for.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const address = searchParams.get('address');
+
+  const querySchema = z.object({
+    address: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  });
+
+  const parsed = querySchema.safeParse({ address });
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: address ? 'Invalid address' : 'Missing wallet address' },
+      { status: 400 }
+    );
+  }
+
+  const apiKey = env.ALCHEMY_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'NFT provider not configured' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const url = `https://eth-mainnet.g.alchemy.com/nft/v2/${apiKey}/getNFTs/?owner=${address}`;
+    const res = await fetch(url);
+    const data = await res.json();
+
+    const nfts = (data.ownedNfts || []).map((nft: any) => ({
+      contract: nft.contract.address as string,
+      id: nft.id.tokenId as string,
+      title: nft.title || nft.metadata?.name,
+      description: nft.metadata?.description,
+      image: nft.media?.[0]?.gateway || nft.media?.[0]?.raw,
+    }));
+
+    return NextResponse.json({ nfts });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/wallet/nfts/page.tsx
+++ b/src/app/wallet/nfts/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useAccount } from 'wagmi';
+import PageLayout from '@/components/PageLayout';
+import { motion } from 'framer-motion';
+import NftGallery from '@/features/wallet/components/NftGallery';
+
+export default function WalletNftsPage() {
+  const { address, isConnected } = useAccount();
+
+  if (!isConnected || !address) {
+    return (
+      <p className="text-white text-center mt-10">
+        Connect your wallet to view NFTs.
+      </p>
+    );
+  }
+
+  return (
+    <PageLayout>
+      <motion.div
+        className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <header className="flex items-center border-b border-white/10 pb-6">
+          <h1 className="text-3xl font-bold tracking-tight text-white">
+            My NFTs
+          </h1>
+        </header>
+
+        <section className="mt-10">
+          <NftGallery address={address} />
+        </section>
+      </motion.div>
+    </PageLayout>
+  );
+}

--- a/src/features/wallet/Dashboard.tsx
+++ b/src/features/wallet/Dashboard.tsx
@@ -2,6 +2,7 @@
 import { useAccount, useBalance, useChainId } from 'wagmi';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { supabase } from '@/lib/supabaseClient';
 import { NETWORKS } from '@/lib/networks';
 import { useUserProfile } from '@/app/hooks/useUserProfile';
@@ -115,6 +116,12 @@ export default function Dashboard() {
         <div className="mt-10">
           <h3 className="text-sm text-gray-400 mb-4">Recent Transactions</h3>
           <TransactionList transactions={transactions} currentAddress={address} />
+        </div>
+
+        <div className="mt-6">
+          <Link href="/wallet/nfts" className="text-indigo-400 hover:underline text-sm">
+            View NFT Gallery
+          </Link>
         </div>
       </div>
 

--- a/src/features/wallet/components/NftGallery.tsx
+++ b/src/features/wallet/components/NftGallery.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchNfts, ParsedNft } from '@/lib/fetchNfts';
+
+type Props = {
+  address: `0x${string}`;
+};
+
+/**
+ * Display NFTs owned by the provided wallet address.
+ */
+export default function NftGallery({ address }: Props) {
+  const [nfts, setNfts] = useState<ParsedNft[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchNfts(address)
+      .then((data) => {
+        if (data.error) setError(data.error);
+        else setNfts(data.nfts);
+      })
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : 'Unknown error')
+      )
+      .finally(() => setLoading(false));
+  }, [address]);
+
+  if (loading)
+    return <p className="text-gray-400 text-sm">Loading NFTs...</p>;
+  if (error) return <p className="text-red-500 text-sm">{error}</p>;
+  if (nfts.length === 0)
+    return <p className="text-gray-500 text-sm">No NFTs found.</p>;
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+      {nfts.map((nft) => (
+        <div
+          key={`${nft.contract}-${nft.id}`}
+          className="border border-white/10 rounded-lg p-2 text-white text-center bg-white/5 backdrop-blur-sm"
+        >
+          {nft.image && (
+            <img
+              src={nft.image}
+              alt={nft.title ?? 'NFT'}
+              className="w-full h-32 object-cover rounded-md mb-2"
+            />
+          )}
+          <p className="text-xs truncate font-semibold">
+            {nft.title ?? `Token ${nft.id}`}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -20,6 +20,7 @@ const serverEnvSchema = z.object({
   ETHERSCAN_API_KEY: z.string(),
   BREVO_API_KEY: z.string(),
   CSRF_SECRET: z.string(),
+  ALCHEMY_API_KEY: z.string().optional(),
 })
 
 // Parse client env inmediatamente (safe)
@@ -47,6 +48,7 @@ export const serverEnv = (() => {
     ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY,
     BREVO_API_KEY: process.env.BREVO_API_KEY,
     CSRF_SECRET: process.env.CSRF_SECRET,
+    ALCHEMY_API_KEY: process.env.ALCHEMY_API_KEY,
   })
 })()
 

--- a/src/lib/fetchNfts.ts
+++ b/src/lib/fetchNfts.ts
@@ -1,0 +1,21 @@
+export interface ParsedNft {
+  contract: string;
+  id: string;
+  title?: string;
+  description?: string;
+  image?: string;
+}
+
+interface ApiResponse {
+  nfts: ParsedNft[];
+  error?: string;
+}
+
+/**
+ * Fetch NFTs for the given wallet address from the API route.
+ */
+export async function fetchNfts(address: string): Promise<ApiResponse> {
+  const res = await fetch(`/api/nfts?address=${address}`);
+  const data = await res.json();
+  return data;
+}


### PR DESCRIPTION
## Summary
- add optional `ALCHEMY_API_KEY` env variable
- add `/api/nfts` API route using Alchemy
- provide small unit tests for the new route
- fetch NFTs with helper util
- create `<NftGallery />` component
- add `/wallet/nfts` page showing the gallery
- link the gallery from the dashboard

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68451b3b54948322ae112af3a0641425